### PR TITLE
global variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 target/
 output/
 build/
-.idea/
 *.class
 *.log
+.idea/
 *.ipr
 *.iml
+.settings/
+.project
+.classpath

--- a/score-lang-api/src/main/java/org/openscore/lang/api/Slang.java
+++ b/score-lang-api/src/main/java/org/openscore/lang/api/Slang.java
@@ -1,14 +1,12 @@
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.api;
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
 
 import org.openscore.events.ScoreEventListener;
 import org.openscore.lang.compiler.SlangSource;
@@ -46,13 +44,14 @@ public interface Slang {
      */
     public CompilationArtifact compileOperation(SlangSource source, String operationName, Set<SlangSource> dependencies);
 
-    /**
-     * Run a flow/operation written in slang already compiled to a compilationArtifact
-     * @param compilationArtifact the compiled artifact of the flow
-     * @param runInputs the inputs for the flow/operation run
-     * @return the execution ID in score
-     */
-    public Long run(CompilationArtifact compilationArtifact, Map<String, Serializable> runInputs);
+	/**
+	 * Run a flow/operation written in slang already compiled to a compilationArtifact
+	 * @param compilationArtifact the compiled artifact of the flow
+	 * @param runInputs the inputs for the flow/operation run
+	 * @param variables the variables for the flow/operation run
+	 * @return the execution ID in score
+	 */
+	public Long run(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> runInputs, Map<String, ? extends Serializable> variables);
 
     /**
      * Compile & run a flow written in slang
@@ -63,16 +62,22 @@ public interface Slang {
      */
     public Long compileAndRun(SlangSource source, Set<SlangSource> dependencies, Map<String, Serializable> runInputs);
 
-    /**
-     * Compile & run an operation written in slang
-     * @param source the slang source containing the operation
-     * @param operationName the name of the operation to compile from the source
-     * @param dependencies a set of slang sources of all the operation's dependencies
-     * @param runInputs the inputs for the operation run
-     * @return the execution ID in score
-     */
-    public Long compileAndRunOperation(SlangSource source, String operationName, Set<SlangSource> dependencies,
-                                       Map<String, Serializable> runInputs);
+	/**
+	 * Compile & run an operation written in slang
+	 * @param source the slang source containing the operation
+	 * @param operationName the name of the operation to compile from the source
+	 * @param dependencies a set of slang sources of all the operation's dependencies
+	 * @param runInputs the inputs for the operation run
+	 * @return the execution ID in score
+	 */
+	public Long compileAndRunOperation(SlangSource source, String operationName, Set<SlangSource> dependencies, Map<String, Serializable> runInputs);
+
+	/**
+	 * Load variable sources written in slang and map them to fully qualified names
+	 * @param sources the slang sources containing the variables
+	 * @return map containing all of the variables with fully qualified keys
+	 */
+	public Map<String, ? extends Serializable> loadVariables(SlangSource... sources);
 
     /**
      * Subscribe on events of score or slang
@@ -92,4 +97,5 @@ public interface Slang {
      * @param eventListener listener for the events
      */
     public void subscribeOnAllEvents(ScoreEventListener eventListener);
+
 }

--- a/score-lang-api/src/main/java/org/openscore/lang/api/Slang.java
+++ b/score-lang-api/src/main/java/org/openscore/lang/api/Slang.java
@@ -17,13 +17,11 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * User: stoneo
- * Date: 03/12/2014
- * Time: 11:28
- */
-
-/**
  * API for using slang
+ *
+ * @author stoneo
+ * @since 03/12/2014
+ * @version $Id$
  */
 public interface Slang {
 
@@ -53,14 +51,15 @@ public interface Slang {
 	 */
 	public Long run(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> runInputs, Map<String, ? extends Serializable> variables);
 
-    /**
-     * Compile & run a flow written in slang
-     * @param source the slang source containing the flow
-     * @param dependencies a set of slang sources of all the flow's dependencies
-     * @param runInputs the inputs for the flow run
-     * @return the execution ID in score
-     */
-    public Long compileAndRun(SlangSource source, Set<SlangSource> dependencies, Map<String, Serializable> runInputs);
+	/**
+	 * Compile & run a flow written in slang
+	 * @param source the slang source containing the flow
+	 * @param dependencies a set of slang sources of all the flow's dependencies
+	 * @param runInputs the inputs for the flow run
+	 * @param variables the variables for the flow/operation run
+	 * @return the execution ID in score
+	 */
+	public Long compileAndRun(SlangSource source, Set<SlangSource> dependencies, Map<String, ? extends Serializable> runInputs, Map<String, ? extends Serializable> variables);
 
 	/**
 	 * Compile & run an operation written in slang
@@ -68,9 +67,11 @@ public interface Slang {
 	 * @param operationName the name of the operation to compile from the source
 	 * @param dependencies a set of slang sources of all the operation's dependencies
 	 * @param runInputs the inputs for the operation run
+	 * @param variables the variables for the flow/operation run
 	 * @return the execution ID in score
 	 */
-	public Long compileAndRunOperation(SlangSource source, String operationName, Set<SlangSource> dependencies, Map<String, Serializable> runInputs);
+	public Long compileAndRunOperation(SlangSource source, String operationName, Set<SlangSource> dependencies, Map<String, ? extends Serializable> runInputs,
+		Map<String, ? extends Serializable> variables);
 
 	/**
 	 * Load variable sources written in slang and map them to fully qualified names

--- a/score-lang-api/src/main/java/org/openscore/lang/api/SlangImpl.java
+++ b/score-lang-api/src/main/java/org/openscore/lang/api/SlangImpl.java
@@ -42,9 +42,9 @@ import static org.openscore.lang.entities.ScoreLangConstants.EVENT_OUTPUT_START;
 import static org.openscore.lang.entities.ScoreLangConstants.SLANG_EXECUTION_EXCEPTION;
 
 /**
- * User: stoneo
- * Date: 03/12/2014
- * Time: 15:20
+ * @author stoneo
+ * @since 03/12/2014
+ * @version $Id$
  */
 public class SlangImpl implements Slang {
 
@@ -93,14 +93,15 @@ public class SlangImpl implements Slang {
 	}
 
 	@Override
-	public Long compileAndRunOperation(SlangSource source, String operationName, Set<SlangSource> dependencies, Map<String, Serializable> runInputs) {
+	public Long compileAndRunOperation(SlangSource source, String operationName, Set<SlangSource> dependencies, Map<String, ? extends Serializable> runInputs,
+		Map<String, ? extends Serializable> variables) {
 		CompilationArtifact compilationArtifact = compileOperation(source, operationName, dependencies);
-		return run(compilationArtifact, runInputs, null);
+		return run(compilationArtifact, runInputs, variables);
 	}
 
 	@Override
-	public Long compileAndRun(SlangSource source, Set<SlangSource> dependencies, Map<String, Serializable> runInputs) {
-		return compileAndRunOperation(source, null, dependencies, runInputs);
+	public Long compileAndRun(SlangSource source, Set<SlangSource> dependencies, Map<String, ? extends Serializable> runInputs, Map<String, ? extends Serializable> variables) {
+		return compileAndRunOperation(source, null, dependencies, runInputs, variables);
 	}
 
 	@Override

--- a/score-lang-api/src/test/java/org/openscore/lang/api/SlangImplTest.java
+++ b/score-lang-api/src/test/java/org/openscore/lang/api/SlangImplTest.java
@@ -190,8 +190,8 @@ public class SlangImplTest {
         SlangSource tempFile = createTempFile();
         CompilationArtifact compilationArtifact = new CompilationArtifact(new ExecutionPlan(), new HashMap<String, ExecutionPlan>(), new ArrayList<Input>());
         Mockito.when(mockSlang.compileOperation(tempFile, "op", new HashSet<SlangSource>())).thenReturn(compilationArtifact);
-        when(mockSlang.compileAndRunOperation(any(SlangSource.class), anyString(), anySetOf(SlangSource.class), anyMapOf(String.class, Serializable.class))).thenCallRealMethod();
-        Long id = mockSlang.compileAndRunOperation(tempFile, "op", new HashSet<SlangSource>(), new HashMap<String, Serializable>());
+        when(mockSlang.compileAndRunOperation(any(SlangSource.class), anyString(), anySetOf(SlangSource.class), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenCallRealMethod();
+        Long id = mockSlang.compileAndRunOperation(tempFile, "op", new HashSet<SlangSource>(), new HashMap<String, Serializable>(), null);
         Assert.assertNotNull(id);
         Mockito.verify(mockSlang).run(compilationArtifact, new HashMap<String, Serializable>(), null);
     }
@@ -203,10 +203,10 @@ public class SlangImplTest {
         Slang mockSlang = Mockito.mock(SlangImpl.class);
         SlangSource tempFile = createTempFile();
 
-        when(mockSlang.compileAndRun(any(SlangSource.class), anySetOf(SlangSource.class), anyMapOf(String.class, Serializable.class))).thenCallRealMethod();
-        Long id = mockSlang.compileAndRun(tempFile, new HashSet<SlangSource>(), new HashMap<String, Serializable>());
+        when(mockSlang.compileAndRun(any(SlangSource.class), anySetOf(SlangSource.class), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenCallRealMethod();
+        Long id = mockSlang.compileAndRun(tempFile, new HashSet<SlangSource>(), new HashMap<String, Serializable>(), null);
         Assert.assertNotNull(id);
-        Mockito.verify(mockSlang).compileAndRunOperation(tempFile, null, new HashSet<SlangSource>(), new HashMap<String, Serializable>());
+        Mockito.verify(mockSlang).compileAndRunOperation(tempFile, null, new HashSet<SlangSource>(), new HashMap<String, Serializable>(), null);
     }
 
     // tests for subscribeOnEvents() method

--- a/score-lang-api/src/test/java/org/openscore/lang/api/SlangImplTest.java
+++ b/score-lang-api/src/test/java/org/openscore/lang/api/SlangImplTest.java
@@ -159,7 +159,7 @@ public class SlangImplTest {
     @Test
     public void testRun(){
         CompilationArtifact compilationArtifact = new CompilationArtifact(new ExecutionPlan(), new HashMap<String, ExecutionPlan>(), new ArrayList<Input>());
-        Long executionId = slang.run(compilationArtifact, new HashMap<String, Serializable>());
+        Long executionId = slang.run(compilationArtifact, new HashMap<String, Serializable>(), null);
         Assert.assertNotNull(executionId);
 
         ArgumentCaptor<TriggeringProperties> argumentCaptor = ArgumentCaptor.forClass(TriggeringProperties.class);
@@ -173,13 +173,13 @@ public class SlangImplTest {
     @Test
     public void testRunWithNullInputs(){
         CompilationArtifact compilationArtifact = new CompilationArtifact(new ExecutionPlan(), new HashMap<String, ExecutionPlan>(), new ArrayList<Input>());
-        Long executionId = slang.run(compilationArtifact, null);
+        Long executionId = slang.run(compilationArtifact, null, null);
         Assert.assertNotNull(executionId);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testRunWithNullCompilationArtifact(){
-        slang.run(null, new HashMap<String, Serializable>());
+        slang.run(null, new HashMap<String, Serializable>(), null);
     }
 
     // tests for compileAndRunOperation() method
@@ -193,7 +193,7 @@ public class SlangImplTest {
         when(mockSlang.compileAndRunOperation(any(SlangSource.class), anyString(), anySetOf(SlangSource.class), anyMapOf(String.class, Serializable.class))).thenCallRealMethod();
         Long id = mockSlang.compileAndRunOperation(tempFile, "op", new HashSet<SlangSource>(), new HashMap<String, Serializable>());
         Assert.assertNotNull(id);
-        Mockito.verify(mockSlang).run(compilationArtifact, new HashMap<String, Serializable>());
+        Mockito.verify(mockSlang).run(compilationArtifact, new HashMap<String, Serializable>(), null);
     }
 
     //tests for compileAndRun() method

--- a/score-lang-api/src/test/java/org/openscore/lang/api/SlangImplTest.java
+++ b/score-lang-api/src/test/java/org/openscore/lang/api/SlangImplTest.java
@@ -1,14 +1,12 @@
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.api;
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
 
 import ch.lambdaj.function.matcher.Predicate;
 import org.junit.Assert;
@@ -44,8 +42,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * User: stoneo
@@ -190,10 +186,10 @@ public class SlangImplTest {
         SlangSource tempFile = createTempFile();
         CompilationArtifact compilationArtifact = new CompilationArtifact(new ExecutionPlan(), new HashMap<String, ExecutionPlan>(), new ArrayList<Input>());
         Mockito.when(mockSlang.compileOperation(tempFile, "op", new HashSet<SlangSource>())).thenReturn(compilationArtifact);
-        when(mockSlang.compileAndRunOperation(any(SlangSource.class), anyString(), anySetOf(SlangSource.class), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenCallRealMethod();
-        Long id = mockSlang.compileAndRunOperation(tempFile, "op", new HashSet<SlangSource>(), new HashMap<String, Serializable>(), null);
+        Mockito.when(mockSlang.compileAndRunOperation(any(SlangSource.class), anyString(), anySetOf(SlangSource.class), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenCallRealMethod();
+        Long id = mockSlang.compileAndRunOperation(tempFile, "op", new HashSet<SlangSource>(), new HashMap<String, Serializable>(), new HashMap<String, Serializable>());
         Assert.assertNotNull(id);
-        Mockito.verify(mockSlang).run(compilationArtifact, new HashMap<String, Serializable>(), null);
+        Mockito.verify(mockSlang).run(compilationArtifact, new HashMap<String, Serializable>(), new HashMap<String, Serializable>());
     }
 
     //tests for compileAndRun() method
@@ -203,10 +199,10 @@ public class SlangImplTest {
         Slang mockSlang = Mockito.mock(SlangImpl.class);
         SlangSource tempFile = createTempFile();
 
-        when(mockSlang.compileAndRun(any(SlangSource.class), anySetOf(SlangSource.class), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenCallRealMethod();
-        Long id = mockSlang.compileAndRun(tempFile, new HashSet<SlangSource>(), new HashMap<String, Serializable>(), null);
+        Mockito.when(mockSlang.compileAndRun(any(SlangSource.class), anySetOf(SlangSource.class), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenCallRealMethod();
+        Long id = mockSlang.compileAndRun(tempFile, new HashSet<SlangSource>(), new HashMap<String, Serializable>(), new HashMap<String, Serializable>());
         Assert.assertNotNull(id);
-        Mockito.verify(mockSlang).compileAndRunOperation(tempFile, null, new HashSet<SlangSource>(), new HashMap<String, Serializable>(), null);
+        Mockito.verify(mockSlang).compileAndRunOperation(tempFile, null, new HashSet<SlangSource>(), new HashMap<String, Serializable>(), new HashMap<String, Serializable>());
     }
 
     // tests for subscribeOnEvents() method
@@ -260,7 +256,7 @@ public class SlangImplTest {
 
         @Bean
         public SlangCompiler compiler() {
-            SlangCompiler compiler = mock(SlangCompiler.class);
+            SlangCompiler compiler = Mockito.mock(SlangCompiler.class);
             CompilationArtifact compilationArtifact = new CompilationArtifact(new ExecutionPlan(), new HashMap<String, ExecutionPlan>(), new ArrayList<Input>());
             Mockito.when(compiler.compileFlow(any(SlangSource.class), anySetOf(SlangSource.class))).thenReturn(compilationArtifact);
             return compiler;
@@ -268,12 +264,12 @@ public class SlangImplTest {
 
         @Bean
         public Score score(){
-            return mock(Score.class);
+            return Mockito.mock(Score.class);
         }
 
         @Bean
         public EventBus eventBus(){
-            return mock(EventBus.class);
+            return Mockito.mock(EventBus.class);
         }
     }
 }

--- a/score-lang-api/src/test/resources/log4j.properties
+++ b/score-lang-api/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO,CONSOLE
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss:SSS} [%-5p] %c{1}: %m (%t, %l)%n

--- a/score-lang-cli/src/main/java/org/openscore/lang/cli/SlangCLI.java
+++ b/score-lang-cli/src/main/java/org/openscore/lang/cli/SlangCLI.java
@@ -1,16 +1,15 @@
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.cli;
 
 import com.google.common.collect.Lists;
+
 import org.openscore.lang.cli.services.ScoreServices;
 import org.openscore.lang.cli.utils.CompilerHelper;
 import org.openscore.lang.entities.CompilationArtifact;
@@ -28,17 +27,17 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
 
 /**
- * Date: 11/7/2014
- *
  * @author lesant
+ * @since 11/07/2014
+ * @version $Id$
  */
-
 @Component
 public class SlangCLI implements CommandMarker {
 
@@ -65,23 +64,21 @@ public class SlangCLI implements CommandMarker {
     @CliCommand(value = "run", help = "triggers a slang flow")
     public String run(
             @CliOption(key = {"", "f", "file"}, mandatory = true, help = "Path to filename. e.g. slang run --f C:\\Slang\\flow.yaml") final File file,
-            @CliOption(key = {"cp", "classpath"}, mandatory = false,
-                    help = "Classpath , a directory comma separated list to flow dependencies, by default it will take flow file dir") final List<String> classPath,
-            //@CliOption(key = "sp", mandatory = false, help = "System property file location") final String systemProperty,//not supported for now...
-            @CliOption(key = {"i", "inputs"}, mandatory = false, help = "inputs in a key=value comma separated list") final Map<String, Serializable> inputs) throws IOException {
-
+            @CliOption(key = {"cp", "classpath"}, mandatory = false, help = "Classpath , a directory comma separated list to flow dependencies, by default it will take flow file dir") final List<String> classPath,
+            @CliOption(key = {"i", "inputs"}, mandatory = false, help = "inputs in a key=value comma separated list") final Map<String, Serializable> inputs,
+            @CliOption(key = {"vf", "variable-file"}, mandatory = false, help = "comma separated list of variable file locations") final List<String> variableFiles) throws IOException {
 
         CompilationArtifact compilationArtifact = compilerHelper.compile(file.getAbsolutePath(), null, classPath);
-
+        Map<String, ? extends Serializable> variables = compilerHelper.loadVariables(variableFiles);
         Long id;
         if (!triggerAsync) {
             StopWatch stopWatch = new StopWatch();
             stopWatch.start();
-            id = scoreServices.triggerSync(compilationArtifact, inputs);
+            id = scoreServices.triggerSync(compilationArtifact, inputs, variables);
             stopWatch.stop();
             return triggerSyncMsg(id, stopWatch.toString());
         }
-        id = scoreServices.trigger(compilationArtifact, inputs);
+        id = scoreServices.trigger(compilationArtifact, inputs, variables);
         return triggerAsyncMsg(id, compilationArtifact.getExecutionPlan().getName());
     }
 

--- a/score-lang-cli/src/main/java/org/openscore/lang/cli/services/ScoreServices.java
+++ b/score-lang-cli/src/main/java/org/openscore/lang/cli/services/ScoreServices.java
@@ -1,17 +1,14 @@
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.cli.services;
 
 import org.openscore.lang.entities.CompilationArtifact;
-
 import org.openscore.events.ScoreEventListener;
 
 import java.io.Serializable;
@@ -19,12 +16,12 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Date: 12/9/2014
- *
  * @author Bonczidai Levente
+ * @since 12/09/2014
+ * @version $Id$
  */
 public interface ScoreServices {
     void subscribe(ScoreEventListener eventHandler, Set<String> eventTypes);
-    Long trigger(CompilationArtifact compilationArtifact, Map<String, Serializable> inputs);
-    Long triggerSync(CompilationArtifact compilationArtifact, Map<String, Serializable> inputs);
+    Long trigger(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> inputs, Map<String, ? extends Serializable> variables);
+    Long triggerSync(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> inputs, Map<String, ? extends Serializable> variables);
 }

--- a/score-lang-cli/src/main/java/org/openscore/lang/cli/services/ScoreServicesImpl.java
+++ b/score-lang-cli/src/main/java/org/openscore/lang/cli/services/ScoreServicesImpl.java
@@ -1,13 +1,11 @@
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.cli.services;
 
 import org.openscore.lang.api.Slang;
@@ -15,7 +13,6 @@ import org.openscore.lang.entities.CompilationArtifact;
 import org.openscore.lang.entities.ScoreLangConstants;
 import org.openscore.lang.runtime.env.ExecutionPath;
 import org.openscore.lang.runtime.events.LanguageEventData;
-
 import org.apache.commons.lang.StringUtils;
 import org.openscore.events.EventConstants;
 import org.openscore.events.ScoreEvent;
@@ -36,13 +33,12 @@ import static org.openscore.lang.entities.ScoreLangConstants.SLANG_EXECUTION_EXC
 import static org.openscore.lang.entities.ScoreLangConstants.EVENT_INPUT_END;
 import static org.openscore.lang.runtime.events.LanguageEventData.EXCEPTION;
 import static org.openscore.lang.runtime.events.LanguageEventData.RESULT;
-
 import static org.fusesource.jansi.Ansi.ansi;
 
 /**
- * Date: 11/13/2014
- *
  * @author Bonczidai Levente
+ * @since 11/13/2014
+ * @version $Id$
  */
 @Service
 public class ScoreServicesImpl implements ScoreServices{
@@ -64,8 +60,9 @@ public class ScoreServicesImpl implements ScoreServices{
      * @param inputs : flow inputs
      * @return executionId
      */
-    public Long trigger(CompilationArtifact compilationArtifact, Map<String, Serializable> inputs) {
-        return slang.run(compilationArtifact, inputs, null);
+    @Override
+	public Long trigger(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> inputs, Map<String, ? extends Serializable> variables) {
+        return slang.run(compilationArtifact, inputs, variables);
     }
 
     /**
@@ -74,7 +71,8 @@ public class ScoreServicesImpl implements ScoreServices{
      * @param inputs : flow inputs
      * @return executionId
      */
-    public Long triggerSync(CompilationArtifact compilationArtifact, Map<String, Serializable> inputs){
+    @Override
+	public Long triggerSync(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> inputs, Map<String, ? extends Serializable> variables){
         //add start event
         Set<String> handlerTypes = new HashSet<>();
         handlerTypes.add(EventConstants.SCORE_FINISHED_EVENT);
@@ -87,18 +85,15 @@ public class ScoreServicesImpl implements ScoreServices{
         SyncTriggerEventListener scoreEventListener = new SyncTriggerEventListener();
         slang.subscribeOnEvents(scoreEventListener, handlerTypes);
 
-        Long executionId = trigger(compilationArtifact, inputs);
+        Long executionId = trigger(compilationArtifact, inputs, variables);
 
         while(!scoreEventListener.isFlowFinished()){
             try {
                 Thread.sleep(200);
             } catch (InterruptedException ignore) {}
         }
-
         slang.unSubscribeOnEvents(scoreEventListener);
-
         return executionId;
-
     }
 
     private class SyncTriggerEventListener implements ScoreEventListener{
@@ -154,6 +149,5 @@ public class ScoreServicesImpl implements ScoreServices{
 
         }
     }
-
 
 }

--- a/score-lang-cli/src/main/java/org/openscore/lang/cli/services/ScoreServicesImpl.java
+++ b/score-lang-cli/src/main/java/org/openscore/lang/cli/services/ScoreServicesImpl.java
@@ -65,7 +65,7 @@ public class ScoreServicesImpl implements ScoreServices{
      * @return executionId
      */
     public Long trigger(CompilationArtifact compilationArtifact, Map<String, Serializable> inputs) {
-        return slang.run(compilationArtifact, inputs);
+        return slang.run(compilationArtifact, inputs, null);
     }
 
     /**

--- a/score-lang-cli/src/main/java/org/openscore/lang/cli/utils/CompilerHelper.java
+++ b/score-lang-cli/src/main/java/org/openscore/lang/cli/utils/CompilerHelper.java
@@ -1,20 +1,24 @@
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.cli.utils;
 
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 import org.openscore.lang.entities.CompilationArtifact;
-import java.io.IOException;
-import java.util.List;
 
 public interface CompilerHelper {
-    public CompilationArtifact compile(String filePath, String opName, List<String> dependencies) throws IOException;
+
+	public CompilationArtifact compile(String filePath, String opName, List<String> dependencies) throws IOException;
+
+	public Map<String, ? extends Serializable> loadVariables(List<String> variableFiles);
+
 }

--- a/score-lang-cli/src/main/java/org/openscore/lang/cli/utils/CompilerHelperImpl.java
+++ b/score-lang-cli/src/main/java/org/openscore/lang/cli/utils/CompilerHelperImpl.java
@@ -1,18 +1,18 @@
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.cli.utils;
 
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
-
 import ch.lambdaj.function.convert.Converter;
+
 import com.google.common.collect.Lists;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.log4j.Logger;
@@ -24,20 +24,22 @@ import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static ch.lambdaj.Lambda.convert;
+
 import static org.openscore.lang.compiler.SlangSource.fromFile;
 
 /**
- * Date: 11/13/2014
- *
  * @author lesant
+ * @since 11/13/2014
+ * @version $Id$
  */
-
 @Component
 public class CompilerHelperImpl implements CompilerHelper{
 
@@ -78,5 +80,15 @@ public class CompilerHelperImpl implements CompilerHelper{
             throw e;
         }
     }
+
+	@Override
+	public Map<String, ? extends Serializable> loadVariables(List<String> variableFiles) {
+		if(CollectionUtils.isEmpty(variableFiles)) return null;
+		SlangSource[] sources = new SlangSource[variableFiles.size()];
+		for(int i = 0; i < variableFiles.size(); i++) {
+			sources[i] = SlangSource.fromFile(new File(variableFiles.get(i)));
+		}
+		return slang.loadVariables(sources);
+	}
 
 }

--- a/score-lang-cli/src/test/java/org/openscore/lang/cli/SlangCLITest.java
+++ b/score-lang-cli/src/test/java/org/openscore/lang/cli/SlangCLITest.java
@@ -71,14 +71,14 @@ public class SlangCLITest {
         long executionID = 1;
 
         when(compilerHelperMock.compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class))).thenReturn(compilationArtifact);
-        when(ScoreServicesMock.triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class))).thenReturn(executionID);
+        when(ScoreServicesMock.triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenReturn(executionID);
 
         CommandResult cr = shell.executeCommand("run --f " + FLOW_PATH_SLAH);
 
         // path may be processed as local in some environments
         // in this case the local directory path is prepended to the actual path
         verify(compilerHelperMock).compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class));
-        verify(ScoreServicesMock).triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class));
+        verify(ScoreServicesMock).triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class));
 
         Assert.assertEquals("method threw exception", null, cr.getException());
         Assert.assertEquals("success should be true", true, cr.isSuccess());
@@ -93,12 +93,12 @@ public class SlangCLITest {
         long executionID = 1;
 
         when(compilerHelperMock.compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class))).thenReturn(compilationArtifact);
-        when(ScoreServicesMock.trigger(eq(compilationArtifact), anyMapOf(String.class, Serializable.class))).thenReturn(executionID);
+        when(ScoreServicesMock.trigger(eq(compilationArtifact), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenReturn(executionID);
 
         CommandResult cr = shell.executeCommand("run --f " + FLOW_PATH_SLAH);
 
         verify(compilerHelperMock).compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class));
-        verify(ScoreServicesMock).trigger(eq(compilationArtifact), anyMapOf(String.class, Serializable.class));
+        verify(ScoreServicesMock).trigger(eq(compilationArtifact), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class));
 
         Assert.assertEquals("method result mismatch", SlangCLI.triggerAsyncMsg(executionID, compilationArtifact.getExecutionPlan().getName()), cr.getResult());
         Assert.assertEquals("method threw exception", null, cr.getException());
@@ -111,12 +111,12 @@ public class SlangCLITest {
         long executionID = 1;
 
         when(compilerHelperMock.compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), anyListOf(String.class))).thenReturn(compilationArtifact);
-        when(ScoreServicesMock.triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class))).thenReturn(executionID);
+        when(ScoreServicesMock.triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenReturn(executionID);
 
         CommandResult cr = shell.executeCommand("run --f " + FLOW_PATH_SLAH + " --cp " + DEPENDENCIES_PATH_SLASH);
 
         verify(compilerHelperMock).compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), anyListOf(String.class));
-        verify(ScoreServicesMock).triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class));
+        verify(ScoreServicesMock).triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class));
 
         Assert.assertEquals("method threw exception", null, cr.getException());
         Assert.assertEquals("success should be true", true, cr.isSuccess());
@@ -132,12 +132,12 @@ public class SlangCLITest {
         inputsMap.put("input2", "value2");
 
         when(compilerHelperMock.compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class))).thenReturn(compilationArtifact);
-        when(ScoreServicesMock.triggerSync(eq(compilationArtifact), eq(inputsMap))).thenReturn(executionID);
+        when(ScoreServicesMock.triggerSync(eq(compilationArtifact), eq(inputsMap), anyMapOf(String.class, Serializable.class))).thenReturn(executionID);
 
         CommandResult cr = shell.executeCommand("run --f " + FLOW_PATH_SLAH + " " + inputsString);
 
         verify(compilerHelperMock).compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class));
-        verify(ScoreServicesMock).triggerSync(eq(compilationArtifact), eq(inputsMap));
+        verify(ScoreServicesMock).triggerSync(eq(compilationArtifact), eq(inputsMap), anyMapOf(String.class, Serializable.class));
 
         Assert.assertEquals("method threw exception", null, cr.getException());
         Assert.assertEquals("success should be true", true, cr.isSuccess());
@@ -156,12 +156,12 @@ public class SlangCLITest {
         inputsMap.put("input2", "value2");
 
         when(compilerHelperMock.compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class))).thenReturn(compilationArtifact);
-        when(ScoreServicesMock.trigger(eq(compilationArtifact), eq(inputsMap))).thenReturn(executionID);
+        when(ScoreServicesMock.trigger(eq(compilationArtifact), eq(inputsMap), anyMapOf(String.class, Serializable.class))).thenReturn(executionID);
 
         CommandResult cr = shell.executeCommand("run --f " + FLOW_PATH_SLAH + " " + inputsString);
 
         verify(compilerHelperMock).compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class));
-        verify(ScoreServicesMock).trigger(eq(compilationArtifact), eq(inputsMap));
+        verify(ScoreServicesMock).trigger(eq(compilationArtifact), eq(inputsMap), anyMapOf(String.class, Serializable.class));
 
         Assert.assertEquals("method result mismatch", SlangCLI.triggerAsyncMsg(executionID, compilationArtifact.getExecutionPlan().getName()), cr.getResult());
         Assert.assertEquals("method threw exception", null, cr.getException());

--- a/score-lang-cli/src/test/java/org/openscore/lang/cli/SlangCLITest.java
+++ b/score-lang-cli/src/test/java/org/openscore/lang/cli/SlangCLITest.java
@@ -204,7 +204,7 @@ public class SlangCLITest {
 
     @Test (timeout = DEFAULT_TIMEOUT)
     public void testGetFlowInputsWithOverride() throws URISyntaxException, IOException {
-        List<Input> inputsList = Lists.newArrayList(new Input("input1", "expression1"),new Input("input_override", "expression_override", false, true, true) , new Input("input2", "expression2"));
+        List<Input> inputsList = Lists.newArrayList(new Input("input1", "expression1"),new Input("input_override", "expression_override", false, true, true, null) , new Input("input2", "expression2"));
         CompilationArtifact compilationArtifact = new CompilationArtifact(new ExecutionPlan(), new HashMap<String, ExecutionPlan>(), inputsList);
 
         when(compilerHelperMock.compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class))).thenReturn(compilationArtifact);

--- a/score-lang-cli/src/test/java/org/openscore/lang/cli/SlangCLITest.java
+++ b/score-lang-cli/src/test/java/org/openscore/lang/cli/SlangCLITest.java
@@ -11,6 +11,7 @@
 package org.openscore.lang.cli;
 
 import com.google.common.collect.Lists;
+
 import org.openscore.lang.cli.services.ScoreServices;
 import org.openscore.lang.cli.utils.CompilerHelper;
 import org.openscore.lang.entities.CompilationArtifact;
@@ -27,6 +28,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -123,7 +125,7 @@ public class SlangCLITest {
     }
 
     @Test (timeout = DEFAULT_TIMEOUT)
-    public void testRunSyncWithInputs() throws URISyntaxException, IOException {
+    public void testRunSyncWithInputs() throws Exception {
         CompilationArtifact compilationArtifact = new CompilationArtifact(new ExecutionPlan(), new HashMap<String, ExecutionPlan>(), new ArrayList<Input>());
         long executionID = 1;
         String inputsString = "--i input1=value1,input2=value2";
@@ -144,7 +146,7 @@ public class SlangCLITest {
     }
 
     @Test (timeout = DEFAULT_TIMEOUT)
-    public void testRunAsyncWithInputs() throws URISyntaxException, IOException {
+    public void testRunAsyncWithInputs() throws Exception {
         //set async mode
         slangCLI.setEnvVar(true);
 
@@ -167,6 +169,24 @@ public class SlangCLITest {
         Assert.assertEquals("method threw exception", null, cr.getException());
         Assert.assertEquals("success should be true", true, cr.isSuccess());
     }
+
+	@Test(timeout = DEFAULT_TIMEOUT)
+	public void testRunSyncWithVariables() throws Exception {
+		CompilationArtifact compilationArtifact = new CompilationArtifact(new ExecutionPlan(), new HashMap<String, ExecutionPlan>(), new ArrayList<Input>());
+		long executionID = 1;
+
+		when(compilerHelperMock.compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class))).thenReturn(compilationArtifact);
+		when(ScoreServicesMock.triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class))).thenReturn(executionID);
+
+		CommandResult cr = shell.executeCommand("run --f " + FLOW_PATH_SLAH + " --vf " + FLOW_PATH_SLAH);
+
+		verify(compilerHelperMock).compile(contains(FLOW_PATH_BACKSLASH), isNull(String.class), isNull(List.class));
+		verify(compilerHelperMock).loadVariables(Arrays.asList(FLOW_PATH_BACKSLASH));
+		verify(ScoreServicesMock).triggerSync(eq(compilationArtifact), anyMapOf(String.class, Serializable.class), anyMapOf(String.class, Serializable.class));
+
+		Assert.assertEquals("method threw exception", null, cr.getException());
+		Assert.assertEquals("success should be true", true, cr.isSuccess());
+	}
 
     @Test (timeout = DEFAULT_TIMEOUT)
     public void testSetEnvVarTrue() {

--- a/score-lang-compiler/src/main/java/org/openscore/lang/compiler/SlangCompiler.java
+++ b/score-lang-compiler/src/main/java/org/openscore/lang/compiler/SlangCompiler.java
@@ -11,11 +11,22 @@ package org.openscore.lang.compiler;/*******************************************
 
 import org.openscore.lang.entities.CompilationArtifact;
 
+import java.io.Serializable;
+import java.util.Map;
 import java.util.Set;
 
 //todo: Eliya - add JavaDoc
 public interface SlangCompiler {
-    CompilationArtifact compileFlow(SlangSource source, Set<SlangSource> path);
+
+	CompilationArtifact compileFlow(SlangSource source, Set<SlangSource> path);
 
     CompilationArtifact compile(SlangSource source, String operationName, Set<SlangSource> path);
+
+    /**
+     * Load variable sources written in slang and map them to fully qualified names
+     * @param sources the slang sources containing the variables
+     * @return map containing all of the variables with fully qualified keys
+     */
+    Map<String, ? extends Serializable> loadVariables(SlangSource... sources);
+
 }

--- a/score-lang-compiler/src/main/java/org/openscore/lang/compiler/SlangCompilerImpl.java
+++ b/score-lang-compiler/src/main/java/org/openscore/lang/compiler/SlangCompilerImpl.java
@@ -12,6 +12,7 @@ package org.openscore.lang.compiler;
 
 import ch.lambdaj.Lambda;
 import ch.lambdaj.function.convert.Converter;
+
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
@@ -28,11 +29,13 @@ import org.openscore.lang.entities.CompilationArtifact;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.io.Serializable;
 import java.util.*;
 
 import static ch.lambdaj.Lambda.convertMap;
 import static ch.lambdaj.Lambda.having;
 import static ch.lambdaj.Lambda.on;
+
 import static org.hamcrest.Matchers.equalTo;
 
 /*
@@ -101,6 +104,22 @@ public class SlangCompilerImpl implements SlangCompiler {
         return new CompilationArtifact(executionPlan, dependencies, executable.getInputs());
     }
 
+	@Override
+	public Map<String, ? extends Serializable> loadVariables(SlangSource... sources) {
+		Validate.notNull(sources, "You must supply a source to load");
+		Map<String, Serializable> result = new HashMap<>();
+		for(SlangSource source : sources) {
+			ParsedSlang parsedSlang = yamlParser.parse(source);
+			Map<String, ? extends Serializable> variables = parsedSlang.getVariables();
+			Validate.notNull(variables, "No variables specified");
+			String namespace = parsedSlang.getNamespace();
+			for(Map.Entry<String, ? extends Serializable> entry : variables.entrySet()) {
+				result.put(namespace + "." + entry.getKey(), entry.getValue());
+			}
+		}
+		return result;
+	}
+
     /**
      * Transforms all of the slang files in the given path to {@link org.openscore.lang.compiler.model.Executable}
      *
@@ -119,6 +138,8 @@ public class SlangCompilerImpl implements SlangCompiler {
                     break;
                 case OPERATIONS:
                     executables.addAll(transformOperations(parsedSlang));
+                    break;
+                case VARIABLES:
                     break;
                 default:
                     throw new RuntimeException("Source: " + source.getName() + " is not of flow type or operations");

--- a/score-lang-compiler/src/main/java/org/openscore/lang/compiler/SlangTextualKeys.java
+++ b/score-lang-compiler/src/main/java/org/openscore/lang/compiler/SlangTextualKeys.java
@@ -43,5 +43,7 @@ public interface SlangTextualKeys {
     String REQUIRED_KEY = "required";
     String ENCRYPTED_KEY = "encrypted";
     String OVERRIDE_KEY = "override";
+    String VARIABLE_KEY = "variable";
+
 }
 

--- a/score-lang-compiler/src/main/java/org/openscore/lang/compiler/model/ParsedSlang.java
+++ b/score-lang-compiler/src/main/java/org/openscore/lang/compiler/model/ParsedSlang.java
@@ -14,6 +14,7 @@ package org.openscore.lang.compiler.model;
  * Created by orius123 on 05/11/14.
  */
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -22,6 +23,7 @@ public class ParsedSlang {
     private Map<String, String> imports;
     private Map<String, Object> flow;
     private List<Map<String, Map<String, Object>>> operations;
+    private Map<String, ? extends Serializable> variables;
     private String namespace;
     private String name;
 
@@ -43,8 +45,14 @@ public class ParsedSlang {
         return operations;
     }
 
+    public Map<String, ? extends Serializable> getVariables() {
+        return variables;
+    }
+
     public Type getType() {
-        return flow != null ? Type.FLOW : Type.OPERATIONS;
+        if(flow != null) return Type.FLOW;
+        if(variables != null) return Type.VARIABLES;
+        return Type.OPERATIONS;
     }
 
     public String getName() {
@@ -55,7 +63,8 @@ public class ParsedSlang {
         this.name = name;
     }
 
-    public enum Type {
-        FLOW, OPERATIONS
+    public static enum Type {
+        FLOW, OPERATIONS, VARIABLES
     }
+
 }

--- a/score-lang-compiler/src/main/java/org/openscore/lang/compiler/transformers/AbstractInputsTransformer.java
+++ b/score-lang-compiler/src/main/java/org/openscore/lang/compiler/transformers/AbstractInputsTransformer.java
@@ -22,49 +22,33 @@ public abstract class AbstractInputsTransformer {
         //- some_input
         //this is our default behavior that if the user specifies only a key, the key is also the ref we look for
         if (rawInput instanceof String) {
-            return (createRefInput((String) rawInput));
+        	String inputName = (String)rawInput;
+            return new Input(inputName, inputName);
         } else if (rawInput instanceof Map) {
-            Map.Entry entry = (Map.Entry) ((Map) rawInput).entrySet().iterator().next();
-            // - some_inputs:
-            //      property1: value1
-            //      property2: value2
-            // this is the verbose way of defining inputs with all of the properties available
+            Map.Entry<String, ?> entry = ((Map<String, ?>)rawInput).entrySet().iterator().next();
             if (entry.getValue() instanceof Map) {
-                return (createPropInput(entry));
+	            // - some_inputs:
+    	        //      property1: value1
+        	    //      property2: value2
+            	// this is the verbose way of defining inputs with all of the properties available
+                return createPropInput((Map.Entry<String, Map<String, Serializable>>)entry);
             }
             // - some_input: some_expression
             // the value of the input is an expression we need to evaluate at runtime
-            else {
-                return (createInlineExpressionInput(entry));
-            }
+			return new Input(entry.getKey(), entry.getValue().toString());
         }
         throw new RuntimeException("Could not transform Input : "+ rawInput);
     }
 
     private Input createPropInput(Map.Entry<String, Map<String, Serializable>> entry) {
-        Map<String, Serializable> prop = entry.getValue();
-        boolean required = !prop.containsKey(SlangTextualKeys.REQUIRED_KEY) || ((boolean) prop.get(SlangTextualKeys.REQUIRED_KEY));//default is required=true
-        boolean encrypted = prop.containsKey(SlangTextualKeys.ENCRYPTED_KEY) && ((boolean) prop.get(SlangTextualKeys.ENCRYPTED_KEY));
-        boolean override = prop.containsKey(SlangTextualKeys.OVERRIDE_KEY) && ((boolean) prop.get(SlangTextualKeys.OVERRIDE_KEY));
-
-        String expressionProp = prop.containsKey(SlangTextualKeys.DEFAULT_KEY) ? (prop.get(SlangTextualKeys.DEFAULT_KEY).toString()) : null;
-
-        return createPropInput(entry.getKey(), required, encrypted, expressionProp, override);
+        Map<String, Serializable> props = entry.getValue();
+        boolean required = !props.containsKey(SlangTextualKeys.REQUIRED_KEY) || ((boolean) props.get(SlangTextualKeys.REQUIRED_KEY));//default is required=true
+        boolean encrypted = props.containsKey(SlangTextualKeys.ENCRYPTED_KEY) && ((boolean) props.get(SlangTextualKeys.ENCRYPTED_KEY));
+        boolean override = props.containsKey(SlangTextualKeys.OVERRIDE_KEY) && ((boolean) props.get(SlangTextualKeys.OVERRIDE_KEY));
+        String inputName = entry.getKey();
+        String expression = props.containsKey(SlangTextualKeys.DEFAULT_KEY) ? props.get(SlangTextualKeys.DEFAULT_KEY).toString() : inputName;
+        String variableName = (String)props.get(SlangTextualKeys.VARIABLE_KEY);
+        return new Input(inputName, expression, encrypted, required, override, variableName);
     }
 
-    private Input createPropInput(String inputName, boolean required,boolean encrypted, String expression,
-                                  boolean override){
-        if(expression == null) {
-            expression = inputName ;
-        }
-        return new Input(inputName, expression, encrypted, required, override);
-    }
-
-    private Input createInlineExpressionInput(Map.Entry<String, Object> entry) {
-        return createPropInput(entry.getKey() , true, false, entry.getValue().toString(), false);
-    }
-
-    private Input createRefInput(String rawInput) {
-        return new Input(rawInput, rawInput);
-    }
 }

--- a/score-lang-compiler/src/main/java/org/openscore/lang/compiler/transformers/AbstractInputsTransformer.java
+++ b/score-lang-compiler/src/main/java/org/openscore/lang/compiler/transformers/AbstractInputsTransformer.java
@@ -1,14 +1,12 @@
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.compiler.transformers;
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
 
 import org.openscore.lang.compiler.SlangTextualKeys;
 import org.openscore.lang.entities.bindings.Input;
@@ -18,37 +16,37 @@ import java.util.Map;
 
 public abstract class AbstractInputsTransformer {
 
-    protected Input transformSingleInput(Object rawInput){
-        //- some_input
-        //this is our default behavior that if the user specifies only a key, the key is also the ref we look for
-        if (rawInput instanceof String) {
-        	String inputName = (String)rawInput;
-            return new Input(inputName, inputName);
-        } else if (rawInput instanceof Map) {
-            Map.Entry<String, ?> entry = ((Map<String, ?>)rawInput).entrySet().iterator().next();
-            if (entry.getValue() instanceof Map) {
-	            // - some_inputs:
-    	        //      property1: value1
-        	    //      property2: value2
-            	// this is the verbose way of defining inputs with all of the properties available
-                return createPropInput((Map.Entry<String, Map<String, Serializable>>)entry);
-            }
-            // - some_input: some_expression
-            // the value of the input is an expression we need to evaluate at runtime
+	protected Input transformSingleInput(Object rawInput) {
+		// - some_input
+		// this is our default behaviour that if the user specifies only a key, the key is also the ref we look for
+		if(rawInput instanceof String) {
+			String inputName = (String)rawInput;
+			return new Input(inputName, inputName);
+		} else if(rawInput instanceof Map) {
+			Map.Entry<String, ?> entry = ((Map<String, ?>)rawInput).entrySet().iterator().next();
+			if(entry.getValue() instanceof Map) {
+				// - some_inputs:
+				// property1: value1
+				// property2: value2
+				// this is the verbose way of defining inputs with all of the properties available
+				return createPropInput((Map.Entry<String, Map<String, Serializable>>)entry);
+			}
+			// - some_input: some_expression
+			// the value of the input is an expression we need to evaluate at runtime
 			return new Input(entry.getKey(), entry.getValue().toString());
-        }
-        throw new RuntimeException("Could not transform Input : "+ rawInput);
-    }
+		}
+		throw new RuntimeException("Could not transform Input : " + rawInput);
+	}
 
-    private Input createPropInput(Map.Entry<String, Map<String, Serializable>> entry) {
-        Map<String, Serializable> props = entry.getValue();
-        boolean required = !props.containsKey(SlangTextualKeys.REQUIRED_KEY) || ((boolean) props.get(SlangTextualKeys.REQUIRED_KEY));//default is required=true
-        boolean encrypted = props.containsKey(SlangTextualKeys.ENCRYPTED_KEY) && ((boolean) props.get(SlangTextualKeys.ENCRYPTED_KEY));
-        boolean override = props.containsKey(SlangTextualKeys.OVERRIDE_KEY) && ((boolean) props.get(SlangTextualKeys.OVERRIDE_KEY));
-        String inputName = entry.getKey();
-        String expression = props.containsKey(SlangTextualKeys.DEFAULT_KEY) ? props.get(SlangTextualKeys.DEFAULT_KEY).toString() : inputName;
-        String variableName = (String)props.get(SlangTextualKeys.VARIABLE_KEY);
-        return new Input(inputName, expression, encrypted, required, override, variableName);
-    }
+	private static Input createPropInput(Map.Entry<String, Map<String, Serializable>> entry) {
+		Map<String, Serializable> props = entry.getValue();
+		boolean required = !props.containsKey(SlangTextualKeys.REQUIRED_KEY) || ((boolean)props.get(SlangTextualKeys.REQUIRED_KEY));// default is required=true
+		boolean encrypted = props.containsKey(SlangTextualKeys.ENCRYPTED_KEY) && ((boolean)props.get(SlangTextualKeys.ENCRYPTED_KEY));
+		boolean override = props.containsKey(SlangTextualKeys.OVERRIDE_KEY) && ((boolean)props.get(SlangTextualKeys.OVERRIDE_KEY));
+		String inputName = entry.getKey();
+		String expression = props.containsKey(SlangTextualKeys.DEFAULT_KEY) ? props.get(SlangTextualKeys.DEFAULT_KEY).toString() : inputName;
+		String variableName = (String)props.get(SlangTextualKeys.VARIABLE_KEY);
+		return new Input(inputName, expression, encrypted, required, override, variableName);
+	}
 
 }

--- a/score-lang-compiler/src/main/java/org/openscore/lang/compiler/utils/ExecutableBuilder.java
+++ b/score-lang-compiler/src/main/java/org/openscore/lang/compiler/utils/ExecutableBuilder.java
@@ -1,13 +1,12 @@
-package org.openscore.lang.compiler.utils;/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.openscore.lang.compiler.utils;
 
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -96,7 +95,7 @@ public class ExecutableBuilder {
 
         String namespace = parsedSlang.getNamespace();
         Map<String, String> imports = parsedSlang.getImports();
-        inputs = resolveVariables(inputs, imports);
+        resolveVariables(inputs, imports);
         switch (parsedSlang.getType()) {
             case FLOW:
                 @SuppressWarnings("unchecked") LinkedHashMap<String, Map<String, Object>> workFlowRawData =
@@ -192,7 +191,7 @@ public class ExecutableBuilder {
         preTaskData.putAll(transformersHandler.runTransformers(taskRawData, preTaskTransformers));
         postTaskData.putAll(transformersHandler.runTransformers(taskRawData, postTaskTransformers));
         List<Input> inputs = (List<Input>)preTaskData.get(SlangTextualKeys.DO_KEY);
-        preTaskData.put(SlangTextualKeys.DO_KEY, (Serializable)resolveVariables(inputs, imports));
+        resolveVariables(inputs, imports);
         @SuppressWarnings("unchecked") Map<String, Object> doRawData = (Map<String, Object>) taskRawData.get(SlangTextualKeys.DO_KEY);
         if (MapUtils.isEmpty(doRawData)) {
             throw new RuntimeException("Task: " + taskName + " has no reference information");
@@ -212,26 +211,23 @@ public class ExecutableBuilder {
         return new Task(taskName, preTaskData, postTaskData, navigationStrings, refId);
     }
 
-	private List<Input> resolveVariables(List<Input> inputs, Map<String, String> imports) {
-		if(inputs == null) return null;
-		List<Input> result = new ArrayList<>();
+	private static void resolveVariables(List<Input> inputs, Map<String, String> imports) {
+		if(inputs == null) return;
 		for(Input input : inputs) {
 			String variableName = input.getVariableName();
 			if(variableName != null) {
 				variableName = resolveRefId(variableName, imports);
-				input = new Input(input, variableName);
+				input.setVariableName(variableName);
 			}
-			result.add(input);
 		}
-		return result;
 	}
 
-    private String resolveRefId(String refIdString, Map<String, String> imports) {
-        String alias = StringUtils.substringBefore(refIdString, ".");
+	private static String resolveRefId(String refIdString, Map<String, String> imports) {
+		String alias = StringUtils.substringBefore(refIdString, ".");
 		Validate.notNull(imports, "No imports specified");
-        if(!imports.containsKey(alias)) throw new RuntimeException("Unresovled alias: " + alias);
-        String refName = StringUtils.substringAfter(refIdString, ".");
-        return imports.get(alias) + "." + refName;
-    }
+		if(!imports.containsKey(alias)) throw new RuntimeException("Unresovled alias: " + alias);
+		String refName = StringUtils.substringAfter(refIdString, ".");
+		return imports.get(alias) + "." + refName;
+	}
 
 }

--- a/score-lang-compiler/src/main/java/org/openscore/lang/compiler/utils/ExecutionStepFactory.java
+++ b/score-lang-compiler/src/main/java/org/openscore/lang/compiler/utils/ExecutionStepFactory.java
@@ -71,7 +71,7 @@ public class ExecutionStepFactory {
         Validate.notNull(preExecutableData, "preExecutableData is null");
         Validate.notNull(execInputs, "Executable inputs are null");
         Map<String, Serializable> actionData = new HashMap<>();
-        actionData.put(ScoreLangConstants.OPERATION_INPUTS_KEY, (Serializable) execInputs);
+        actionData.put(ScoreLangConstants.EXECUTABLE_INPUTS_KEY, (Serializable) execInputs);
         actionData.put(ScoreLangConstants.HOOKS, (Serializable) preExecutableData);
         actionData.put(ScoreLangConstants.NODE_NAME_KEY, executableName);
         actionData.put(ScoreLangConstants.NEXT_STEP_ID_KEY, index + 1);

--- a/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompileBasicFlowTest.java
+++ b/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompileBasicFlowTest.java
@@ -1,13 +1,11 @@
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.compiler;
 
 import org.junit.Assert;
@@ -28,12 +26,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.io.Serializable;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 
 /*
  * Created by orius123 on 05/11/14.
@@ -49,14 +48,12 @@ public class CompileBasicFlowTest {
     public void testCompileFlowBasic() throws Exception {
         URI flow = getClass().getResource("/flow.yaml").toURI();
         URI operation = getClass().getResource("/operation.yaml").toURI();
-//URI params = getClass().getResource("/vars.yaml").toURI();
+//URI vars = getClass().getResource("/variables.yaml").toURI();
         Set<SlangSource> path = new HashSet<>();
         path.add(SlangSource.fromFile(operation));
-//path.add(SlangSource.fromFile(params));
+//path.add(SlangSource.fromFile(vars));
         CompilationArtifact compilationArtifact = compiler.compileFlow(SlangSource.fromFile(flow), path);
         ExecutionPlan executionPlan = compilationArtifact.getExecutionPlan();
-System.out.println(executionPlan);
-System.out.println(compilationArtifact.getDependencies());
         Assert.assertNotNull("execution plan is null", executionPlan);
         Assert.assertEquals("there is a different number of steps than expected", 4, executionPlan.getSteps().size());
         Assert.assertEquals("execution plan name is different than expected", "basic_flow", executionPlan.getName());
@@ -137,5 +134,16 @@ System.out.println(compilationArtifact.getDependencies());
         Assert.assertEquals("The flow dependency full name is wrong", "user.ops.test_op", dependency.getKey());
     }
 
+	@Test
+	public void testLoadVariables() throws Exception {
+		Map<String, Serializable> expected = new HashMap<>();
+		expected.put("test.env.vars.host", "localhost");
+		expected.put("test.env.vars.port", 22);
+		expected.put("test.env.vars.alla", "balla");
+		URI vars = getClass().getResource("/variables.yaml").toURI();
+		Map<String, ? extends Serializable> result = compiler.loadVariables(SlangSource.fromFile(vars));
+		Assert.assertNotNull(result);
+		Assert.assertEquals(expected, result);
+	}
 
 }

--- a/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompileBasicFlowTest.java
+++ b/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompileBasicFlowTest.java
@@ -47,17 +47,19 @@ public class CompileBasicFlowTest {
     public void testCompileFlowBasic() throws Exception {
         URI flow = getClass().getResource("/flow.yaml").toURI();
         URI operation = getClass().getResource("/operation.yaml").toURI();
-
+//URI params = getClass().getResource("/vars.yaml").toURI();
         Set<SlangSource> path = new HashSet<>();
         path.add(SlangSource.fromFile(operation));
-
+//path.add(SlangSource.fromFile(params));
         CompilationArtifact compilationArtifact = compiler.compileFlow(SlangSource.fromFile(flow), path);
         ExecutionPlan executionPlan = compilationArtifact.getExecutionPlan();
+System.out.println(executionPlan);
+System.out.println(compilationArtifact.getDependencies());
         Assert.assertNotNull("execution plan is null", executionPlan);
         Assert.assertEquals("there is a different number of steps than expected", 4, executionPlan.getSteps().size());
         Assert.assertEquals("execution plan name is different than expected", "basic_flow", executionPlan.getName());
         Assert.assertEquals("the dependencies size is not as expected", 1, compilationArtifact.getDependencies().size());
-        Assert.assertEquals("the inputs size is not as expected", 1, compilationArtifact.getInputs().size());
+        Assert.assertEquals("the inputs size is not as expected", 2, compilationArtifact.getInputs().size());
     }
 
     @Test
@@ -76,7 +78,7 @@ public class CompileBasicFlowTest {
         Assert.assertEquals("the dependencies size is not as expected", 1, compilationArtifact.getDependencies().size());
 
         ExecutionStep startStep = executionPlan.getStep(1L);
-        @SuppressWarnings("unchecked") List<Input> inputs = (List<Input>) startStep.getActionData().get(ScoreLangConstants.OPERATION_INPUTS_KEY);
+        @SuppressWarnings("unchecked") List<Input> inputs = (List<Input>) startStep.getActionData().get(ScoreLangConstants.EXECUTABLE_INPUTS_KEY);
         Assert.assertNotNull("inputs doesn't exist", inputs);
         Assert.assertEquals("there is a different number of inputs than expected", 1, inputs.size());
 

--- a/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompileOperationTest.java
+++ b/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompileOperationTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.net.URL;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -52,12 +51,22 @@ public class CompileOperationTest {
     @Test
     public void testCompileOperationBasic() throws Exception {
         URL resource = getClass().getResource("/operation.yaml");
-//URL vars = getClass().getResource("/vars.yaml");
+//URL vars = getClass().getResource("/variables.yaml");
 //ExecutionPlan executionPlan = compiler.compile(SlangSource.fromFile(resource.toURI()), "test_op", Collections.singleton(SlangSource.fromFile(vars.toURI()))).getExecutionPlan();
         ExecutionPlan executionPlan = compiler.compile(SlangSource.fromFile(resource.toURI()), "test_op", null).getExecutionPlan();
         Assert.assertNotNull("execution plan is null", executionPlan);
         Assert.assertEquals("there is a different number of steps than expected", 3, executionPlan.getSteps().size());
     }
+
+	@Test
+	public void testCompileOperationMissingImport() throws Exception {
+		URL resource = getClass().getResource("/operation_mi.yaml");
+//URL vars = getClass().getResource("/variables.yaml");
+//ExecutionPlan executionPlan = compiler.compile(SlangSource.fromFile(resource.toURI()), "test_op", Collections.singleton(SlangSource.fromFile(vars.toURI()))).getExecutionPlan();
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("import");
+		compiler.compile(SlangSource.fromFile(resource.toURI()), "test_op", null).getExecutionPlan();
+	}
 
     @Test
     public void wrongOperationName() throws Exception {

--- a/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompileOperationTest.java
+++ b/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompileOperationTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 
 /*
@@ -43,6 +44,8 @@ public class CompileOperationTest {
     @Test
     public void testCompileOperationBasic() throws Exception {
         URL resource = getClass().getResource("/operation.yaml");
+//URL vars = getClass().getResource("/vars.yaml");
+//ExecutionPlan executionPlan = compiler.compile(SlangSource.fromFile(resource.toURI()), "test_op", Collections.singleton(SlangSource.fromFile(vars.toURI()))).getExecutionPlan();
         ExecutionPlan executionPlan = compiler.compile(SlangSource.fromFile(resource.toURI()), "test_op", null).getExecutionPlan();
         Assert.assertNotNull("execution plan is null", executionPlan);
         Assert.assertEquals("there is a different number of steps than expected", 3, executionPlan.getSteps().size());
@@ -63,7 +66,7 @@ public class CompileOperationTest {
         ExecutionPlan executionPlan = compiler.compile(SlangSource.fromFile(resource.toURI()), "test_op_2", null).getExecutionPlan();
 
         ExecutionStep startStep = executionPlan.getStep(1L);
-        @SuppressWarnings("unchecked") List<Input> inputs = (List<Input>) startStep.getActionData().get(ScoreLangConstants.OPERATION_INPUTS_KEY);
+        @SuppressWarnings("unchecked") List<Input> inputs = (List<Input>) startStep.getActionData().get(ScoreLangConstants.EXECUTABLE_INPUTS_KEY);
         Assert.assertNotNull("inputs doesn't exist", inputs);
         Assert.assertEquals("there is a different number of inputs than expected", 13, inputs.size());
 

--- a/score-lang-compiler/src/test/java/org/openscore/lang/compiler/utils/ExecutionStepFactoryTest.java
+++ b/score-lang-compiler/src/test/java/org/openscore/lang/compiler/utils/ExecutionStepFactoryTest.java
@@ -43,8 +43,8 @@ public class ExecutionStepFactoryTest {
     public void testCreateStartStepPutInputsUnderTheRightKey() throws Exception {
         ArrayList<Input> execInputs = new ArrayList<>();
         ExecutionStep startStep = factory.createStartStep(1L, new HashMap<String, Serializable>(), execInputs,"");
-        Assert.assertNotNull("inputs key is null", startStep.getActionData().get(ScoreLangConstants.OPERATION_INPUTS_KEY));
-        Assert.assertSame("inputs are not set under their key", execInputs, startStep.getActionData().get(ScoreLangConstants.OPERATION_INPUTS_KEY));
+        Assert.assertNotNull("inputs key is null", startStep.getActionData().get(ScoreLangConstants.EXECUTABLE_INPUTS_KEY));
+        Assert.assertSame("inputs are not set under their key", execInputs, startStep.getActionData().get(ScoreLangConstants.EXECUTABLE_INPUTS_KEY));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/score-lang-compiler/src/test/resources/flow.yaml
+++ b/score-lang-compiler/src/test/resources/flow.yaml
@@ -2,16 +2,21 @@ namespace: user.ops
 
 imports:
   ops: user.ops
+  vars: test.env.vars
 
 flow:
   name: basic_flow
   inputs:
     - input1
+    - host:
+        variable: vars.host
   workflow:
     CheckWeather:
       do:
         ops.test_op:
           - city: str('input_1')
+          - port:
+              variable: vars.port
       publish:
         - weather
       navigate:

--- a/score-lang-compiler/src/test/resources/operation.yaml
+++ b/score-lang-compiler/src/test/resources/operation.yaml
@@ -1,7 +1,13 @@
 namespace: user.ops
 
+imports:
+  vars: test.env.vars
+
 operations:
   - test_op:
+      inputs:
+        - alla:
+            variable: vars.alla
       action:
         python_script: 'print "hello world"'
 

--- a/score-lang-compiler/src/test/resources/operation_mi.yaml
+++ b/score-lang-compiler/src/test/resources/operation_mi.yaml
@@ -1,0 +1,9 @@
+namespace: user.ops
+
+operations:
+  - test_op:
+      inputs:
+        - alla:
+            variable: vars.alla
+      action:
+        python_script: 'print "hello world"'

--- a/score-lang-compiler/src/test/resources/variables.yaml
+++ b/score-lang-compiler/src/test/resources/variables.yaml
@@ -1,0 +1,6 @@
+namespace: test.env.vars
+
+variables:
+  host: localhost
+  port: 22
+  alla: balla

--- a/score-lang-entities/src/main/java/org/openscore/lang/entities/ScoreLangConstants.java
+++ b/score-lang-entities/src/main/java/org/openscore/lang/entities/ScoreLangConstants.java
@@ -20,6 +20,7 @@ public interface ScoreLangConstants {
     String RUN_ENV = "runEnv";
     String HOOKS = "hooks";
     String NODE_NAME_KEY = "nodeName";
+//    String NAMESPACE_ALIASES = "namespaceAliases";
 
     //action scope
     String ACTION_CLASS_KEY = "className";
@@ -31,7 +32,7 @@ public interface ScoreLangConstants {
     String NEXT_STEP_ID_KEY = "nextStepId";
 
     //operation scope
-    String OPERATION_INPUTS_KEY = "operationInputs";
+    String EXECUTABLE_INPUTS_KEY = "executableInputs";
     String BIND_OUTPUT_FROM_INPUTS_KEY = "fromInputs";
     String USER_INPUTS_KEY = "userInputs";
     String EXECUTABLE_OUTPUTS_KEY = "executableOutputs";

--- a/score-lang-entities/src/main/java/org/openscore/lang/entities/ScoreLangConstants.java
+++ b/score-lang-entities/src/main/java/org/openscore/lang/entities/ScoreLangConstants.java
@@ -1,13 +1,11 @@
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.entities;
 
 /**
@@ -20,7 +18,6 @@ public interface ScoreLangConstants {
     String RUN_ENV = "runEnv";
     String HOOKS = "hooks";
     String NODE_NAME_KEY = "nodeName";
-//    String NAMESPACE_ALIASES = "namespaceAliases";
 
     //action scope
     String ACTION_CLASS_KEY = "className";

--- a/score-lang-entities/src/main/java/org/openscore/lang/entities/bindings/Input.java
+++ b/score-lang-entities/src/main/java/org/openscore/lang/entities/bindings/Input.java
@@ -21,19 +21,22 @@ public class Input extends InOutParam {
 	private final boolean encrypted;
 	private final boolean required;
 	private final boolean override;
+	private final String variableName;
 
-	public Input(String name, String expression) {
-		super(name, expression);
-		this.encrypted = false;
-		this.required = true;
-		this.override = false;
-	}
-
-	public Input(String name, String expression, boolean encrypted, boolean required, boolean override) {
+	public Input(String name, String expression, boolean encrypted, boolean required, boolean override, String variableName) {
 		super(name, expression);
 		this.encrypted = encrypted;
 		this.required = required;
 		this.override = override;
+		this.variableName = variableName;
+	}
+
+	public Input(String name, String expression) {
+		this(name, expression, false, true, false, null);
+	}
+
+	public Input(Input input, String fqvn) {
+		this(input.getName(), input.getExpression(), input.isEncrypted(), input.isRequired(), input.isOverride(), fqvn);
 	}
 
 	public boolean isEncrypted() {
@@ -46,6 +49,10 @@ public class Input extends InOutParam {
 
 	public boolean isOverride() {
 		return override;
+	}
+
+	public String getVariableName() {
+		return this.variableName;
 	}
 
 }

--- a/score-lang-entities/src/main/java/org/openscore/lang/entities/bindings/Input.java
+++ b/score-lang-entities/src/main/java/org/openscore/lang/entities/bindings/Input.java
@@ -1,12 +1,11 @@
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.openscore.lang.entities.bindings;
 
 /**
@@ -21,7 +20,7 @@ public class Input extends InOutParam {
 	private final boolean encrypted;
 	private final boolean required;
 	private final boolean override;
-	private final String variableName;
+	private String variableName;
 
 	public Input(String name, String expression, boolean encrypted, boolean required, boolean override, String variableName) {
 		super(name, expression);
@@ -33,10 +32,6 @@ public class Input extends InOutParam {
 
 	public Input(String name, String expression) {
 		this(name, expression, false, true, false, null);
-	}
-
-	public Input(Input input, String fqvn) {
-		this(input.getName(), input.getExpression(), input.isEncrypted(), input.isRequired(), input.isOverride(), fqvn);
 	}
 
 	public boolean isEncrypted() {
@@ -53,6 +48,10 @@ public class Input extends InOutParam {
 
 	public String getVariableName() {
 		return this.variableName;
+	}
+
+	public void setVariableName(String variableName) {
+		this.variableName = variableName;
 	}
 
 }

--- a/score-lang-runtime/src/main/java/org/openscore/lang/runtime/bindings/InputsBinding.java
+++ b/score-lang-runtime/src/main/java/org/openscore/lang/runtime/bindings/InputsBinding.java
@@ -30,24 +30,23 @@ public class InputsBinding {
 
     /**
      * Binds the inputs to a new result map
-     * @param context : initial context
      * @param inputs : the inputs to bind
+     * @param context : initial context
      * @return : a new map with all inputs resolved (does not include initial context)
      */
-    public Map<String,Serializable> bindInputs(Map<String,Serializable> context,
-                                               List<Input> inputs){
+    public Map<String,Serializable> bindInputs(List<Input> inputs, Map<String, ? extends Serializable> context, Map<String, ? extends Serializable> variables) {
         Map<String,Serializable> resultContext = new HashMap<>();
         Map<String,Serializable> srcContext = new HashMap<>(context); //we do not want to change original context map
         for(Input input : inputs){
-            bindInput(input,srcContext,resultContext);
+            bindInput(input, srcContext, resultContext, variables);
         }
         return resultContext;
     }
 
-    private void bindInput(Input input, Map<String,Serializable> context,Map<String,Serializable> targetContext) {
+    private void bindInput(Input input, Map<String, ? extends Serializable> context, Map<String, Serializable> targetContext, Map<String, ? extends Serializable> variables) {
         String inputName = input.getName();
         Validate.notEmpty(inputName);
-        Serializable value = resolveValue(inputName, input, context, targetContext);
+        Serializable value = resolveValue(input, context, targetContext, variables);
 
         if(input.isRequired() && value == null) {
             throw new RuntimeException("Input with name : "+ inputName + " is Required, but value is empty");// todo : add stepName here?
@@ -56,14 +55,12 @@ public class InputsBinding {
         targetContext.put(inputName,value);
     }
 
-    private Serializable resolveValue(String inputName, Input input, Map<String, Serializable> context,
-                                      Map<String, Serializable> targetContext) {
+    private Serializable resolveValue(Input input, Map<String, ? extends Serializable> context, Map<String, ? extends Serializable> targetContext, Map<String, ? extends Serializable> variables) {
         Serializable value = null;
-
-        if(context.containsKey(inputName) && !input.isOverride()){
-            value = context.get(inputName);
-        }
-
+        String inputName = input.getName();
+        if(context.containsKey(inputName) && !input.isOverride()) value = context.get(inputName);
+        String fqvn = input.getVariableName();
+        if(value == null && fqvn != null && variables != null) value = variables.get(fqvn);
         if(value == null && StringUtils.isNotEmpty(input.getExpression())){
             Map<String,Serializable> scriptContext = new HashMap<>(context); //we do not want to change original context map
             scriptContext.putAll(targetContext);//so you can resolve previous inputs already binded
@@ -71,9 +68,7 @@ public class InputsBinding {
             String expr = input.getExpression();
             value = scriptEvaluator.evalExpr(expr, scriptContext);
         }
-
         return value;
     }
-
 
 }

--- a/score-lang-runtime/src/main/java/org/openscore/lang/runtime/env/RunEnvironment.java
+++ b/score-lang-runtime/src/main/java/org/openscore/lang/runtime/env/RunEnvironment.java
@@ -39,7 +39,7 @@ public class RunEnvironment implements Serializable{
     private ParentFlowStack parentFlowStack;
 
     private ExecutionPath executionPath;
-
+    private final Map<String, Serializable> variables;
     // Map holding serializable data that is common for the entire run.
     // This is data that should be shred between different actions with the ability to change the data
     private Map<String, SerializableSessionObject> serializableDataMap;
@@ -51,6 +51,7 @@ public class RunEnvironment implements Serializable{
         callArguments = new HashMap<>();
         executionPath = new ExecutionPath();
         serializableDataMap = new HashMap<>();
+        variables = new HashMap<>();
     }
 
     public ContextStack getStack(){
@@ -93,6 +94,10 @@ public class RunEnvironment implements Serializable{
 
     public ExecutionPath getExecutionPath() {
         return this.executionPath;
+    }
+
+    public Map<String, Serializable> getVariables() {
+        return variables;
     }
 
     public Map<String, SerializableSessionObject> getSerializableDataMap() {

--- a/score-lang-runtime/src/main/java/org/openscore/lang/runtime/steps/AbstractSteps.java
+++ b/score-lang-runtime/src/main/java/org/openscore/lang/runtime/steps/AbstractSteps.java
@@ -47,12 +47,8 @@ public abstract class AbstractSteps {
     protected void updateCallArgumentsAndPushContextToStack(RunEnvironment runEnvironment, Map<String, Serializable> currentContext, Map<String, Serializable> callArguments) {
         ContextStack contextStack = runEnvironment.getStack();
         contextStack.pushContext(currentContext);
-        updateCallArguments(runEnvironment, callArguments);
-    }
-
-    private void updateCallArguments(RunEnvironment runEnvironment, Map<String, Serializable> newContext) {
         //TODO: put a deep clone of the new context
-        runEnvironment.putCallArguments(newContext);
+        runEnvironment.putCallArguments(callArguments);
     }
 
     @SafeVarargs

--- a/score-lang-runtime/src/main/java/org/openscore/lang/runtime/steps/ExecutableSteps.java
+++ b/score-lang-runtime/src/main/java/org/openscore/lang/runtime/steps/ExecutableSteps.java
@@ -23,16 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.openscore.lang.entities.ScoreLangConstants.EVENT_EXECUTION_FINISHED;
-import static org.openscore.lang.entities.ScoreLangConstants.EVENT_OUTPUT_END;
-import static org.openscore.lang.entities.ScoreLangConstants.EVENT_OUTPUT_START;
-import static org.openscore.lang.entities.ScoreLangConstants.EXECUTABLE_OUTPUTS_KEY;
-import static org.openscore.lang.entities.ScoreLangConstants.EXECUTABLE_RESULTS_KEY;
-import static org.openscore.lang.entities.ScoreLangConstants.NEXT_STEP_ID_KEY;
-import static org.openscore.lang.entities.ScoreLangConstants.NODE_NAME_KEY;
-import static org.openscore.lang.entities.ScoreLangConstants.OPERATION_INPUTS_KEY;
-import static org.openscore.lang.entities.ScoreLangConstants.RUN_ENV;
-import static org.openscore.lang.entities.ScoreLangConstants.USER_INPUTS_KEY;
+import static org.openscore.lang.entities.ScoreLangConstants.*;
 import static org.openscore.lang.runtime.events.LanguageEventData.OUTPUTS;
 import static org.openscore.lang.runtime.events.LanguageEventData.RESULT;
 import static org.openscore.lang.runtime.events.LanguageEventData.levelName;
@@ -55,7 +46,7 @@ public class ExecutableSteps extends AbstractSteps {
     @Autowired
     private OutputsBinding outputsBinding;
 
-    public void startExecutable(@Param(OPERATION_INPUTS_KEY) List<Input> operationInputs,
+    public void startExecutable(@Param(EXECUTABLE_INPUTS_KEY) List<Input> executableInputs,
                                 @Param(RUN_ENV) RunEnvironment runEnv,
                                 @Param(USER_INPUTS_KEY) Map<String, ? extends Serializable> userInputs,
                                 @Param(EXECUTION_RUNTIME_SERVICES) ExecutionRuntimeServices executionRuntimeServices,
@@ -67,12 +58,12 @@ public class ExecutableSteps extends AbstractSteps {
         if(userInputs != null) {
             callArguments.putAll(userInputs);
         }
-        Map<String, Serializable>  operationContext = inputsBinding.bindInputs(callArguments,operationInputs);
+        Map<String, Serializable> executableContext = inputsBinding.bindInputs(executableInputs, callArguments, runEnv.getVariables());
 
         Map<String, Serializable> actionArguments = new HashMap<>();
 
         //todo: clone action context before updating
-        actionArguments.putAll(operationContext);
+        actionArguments.putAll(executableContext);
 
         //done with the user inputs, don't want it to be available in next startExecutable steps..
         if(userInputs != null) {
@@ -81,9 +72,9 @@ public class ExecutableSteps extends AbstractSteps {
 
         //todo: hook
 
-        updateCallArgumentsAndPushContextToStack(runEnv, operationContext, actionArguments);
+        updateCallArgumentsAndPushContextToStack(runEnv, executableContext, actionArguments);
 
-        sendBindingInputsEvent(operationInputs, operationContext, runEnv, executionRuntimeServices,
+        sendBindingInputsEvent(executableInputs, executableContext, runEnv, executionRuntimeServices,
                 "Post Input binding for operation/flow",nodeName, levelName.EXECUTABLE_NAME);
 
         // put the next step position for the navigation

--- a/score-lang-runtime/src/main/java/org/openscore/lang/runtime/steps/TaskSteps.java
+++ b/score-lang-runtime/src/main/java/org/openscore/lang/runtime/steps/TaskSteps.java
@@ -71,7 +71,7 @@ public class TaskSteps extends AbstractSteps {
 
         Map<String, Serializable> flowContext = runEnv.getStack().popContext();
 
-        Map<String, Serializable> operationArguments = inputsBinding.bindInputs(flowContext, taskInputs);
+        Map<String, Serializable> operationArguments = inputsBinding.bindInputs(taskInputs, flowContext, runEnv.getVariables());
 
         //todo: hook
 

--- a/score-lang-runtime/src/test/java/org/openscore/lang/runtime/bindings/InputsBindingTest.java
+++ b/score-lang-runtime/src/test/java/org/openscore/lang/runtime/bindings/InputsBindingTest.java
@@ -14,7 +14,6 @@ import org.openscore.lang.entities.bindings.Input;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.python.google.common.collect.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,14 +38,14 @@ public class InputsBindingTest {
     @Test
     public void testEmptyBindInputs() throws Exception {
         List<Input> inputs = Arrays.asList();
-        Map<String,Serializable> result = inputsBinding.bindInputs(new HashMap<String,Serializable>(),inputs);
+        Map<String,Serializable> result = bindInputs(inputs);
         Assert.assertTrue(result.isEmpty());
     }
 
     @Test
     public void testDefaultValue() throws Exception {
-        List<Input> inputs = Lists.newArrayList(createDefaultValueInput("str('value')"));
-        Map<String,Serializable> result = inputsBinding.bindInputs(new HashMap<String,Serializable>(),inputs);
+        List<Input> inputs = Arrays.asList(createDefaultValueInput("str('value')"));
+        Map<String,Serializable> result = bindInputs(inputs);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals("value", result.get("input1"));
@@ -54,8 +53,8 @@ public class InputsBindingTest {
 
     @Test
     public void testDefaultValueInt() throws Exception {
-        List<Input> inputs = Lists.newArrayList(createDefaultValueInput("2"));
-        Map<String,Serializable> result = inputsBinding.bindInputs(new HashMap<String,Serializable>(),inputs);
+        List<Input> inputs = Arrays.asList(createDefaultValueInput("2"));
+        Map<String,Serializable> result = bindInputs(inputs);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(2, result.get("input1"));
@@ -64,7 +63,7 @@ public class InputsBindingTest {
 	@Test
 	public void testDefaultValueBoolean() throws Exception {
 		List<Input> inputs = Arrays.asList(new Input("input1", "true"), new Input("input2", "false"), new Input("input3", "str('phrase cantaining true and false')"));
-		Map<String, Serializable> result = inputsBinding.bindInputs(new HashMap<String, Serializable>(), inputs);
+		Map<String, Serializable> result = bindInputs(inputs);
 		Assert.assertTrue((boolean)result.get("input1"));
 		Assert.assertFalse((boolean)result.get("input2"));
 		Assert.assertEquals("phrase cantaining true and false", result.get("input3"));
@@ -72,8 +71,8 @@ public class InputsBindingTest {
 
     @Test
     public void testTwoInputs() throws Exception {
-        List<Input> inputs =  Arrays.asList(new Input("input2","'yyy'",false,false,false),createDefaultValueInput("'zzz'"));
-        Map<String,Serializable> result = inputsBinding.bindInputs(new HashMap<String,Serializable>(),inputs);
+        List<Input> inputs =  Arrays.asList(new Input("input2","'yyy'",false,false,false, null),createDefaultValueInput("'zzz'"));
+        Map<String,Serializable> result = bindInputs(inputs);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals("zzz", result.get("input1"));
@@ -86,7 +85,7 @@ public class InputsBindingTest {
         Map<String,Serializable> context = new HashMap<>();
         context.put("inputX","xxx");
         List<Input> inputs =  Arrays.asList(new Input("input1","str(inputX)"));
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals("xxx", result.get("input1"));
@@ -100,7 +99,7 @@ public class InputsBindingTest {
         context.put("valX",5);
         Input scriptInput = new Input("input1","3 + valX");
         List<Input> inputs = Arrays.asList(scriptInput);
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(8, result.get("input1"));
@@ -115,7 +114,7 @@ public class InputsBindingTest {
         context.put("valC","c");
         Input scriptInput = new Input("input1"," 'a' + valB + valC");
         List<Input> inputs = Arrays.asList(scriptInput);
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals("abc", result.get("input1"));
@@ -125,10 +124,10 @@ public class InputsBindingTest {
     public void testDefaultValueVsEmptyRef() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
 
-        Input refInput = new Input("input1","str('val')",false,false,false);
+        Input refInput = new Input("input1","str('val')",false,false,false, null);
         List<Input> inputs = Arrays.asList(refInput);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals("val", result.get("input1"));
@@ -140,10 +139,10 @@ public class InputsBindingTest {
     public void testAssignFromAndExpr() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",3);
-        Input input = new Input("input1","5+7",false,false,false);
+        Input input = new Input("input1","5+7",false,false,false, null);
         List<Input> inputs = Arrays.asList(input);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(3, result.get("input1"));
@@ -156,10 +155,10 @@ public class InputsBindingTest {
     public void testAssignFromAndConst() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",3);
-        Input input = new Input("input1","5",false,false,false);
+        Input input = new Input("input1","5",false,false,false, null);
         List<Input> inputs = Arrays.asList(input);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(3, result.get("input1"));
@@ -169,10 +168,10 @@ public class InputsBindingTest {
     public void testComplexExpr() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",3);
-        Input input = new Input("input2"," input1 + 3 * 2 ",false,false,false);
+        Input input = new Input("input2"," input1 + 3 * 2 ",false,false,false, null);
         List<Input> inputs = Arrays.asList(input);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input2"));
         Assert.assertEquals(9, result.get("input2"));
@@ -184,10 +183,10 @@ public class InputsBindingTest {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input2",3);
         context.put("input1",5);
-        Input input = new Input("input1","input2",false,false,false);
+        Input input = new Input("input1","input2",false,false,false, null);
         List<Input> inputs = Arrays.asList(input);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(5, result.get("input1"));
@@ -199,10 +198,10 @@ public class InputsBindingTest {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input2",3);
         context.put("input1",5);
-        Input input = new Input("input1","input2",false,false,true);
+        Input input = new Input("input1","input2",false,false,true, null);
         List<Input> inputs = Arrays.asList(input);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(3, result.get("input1"));
@@ -215,10 +214,10 @@ public class InputsBindingTest {
     public void testOverrideAssignFrom2() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",5);
-        Input input = new Input("input1","3",false,false,true);
+        Input input = new Input("input1","3",false,false,true, null);
         List<Input> inputs = Arrays.asList(input);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(3, result.get("input1"));
@@ -229,10 +228,10 @@ public class InputsBindingTest {
     public void testOverrideAssignFrom3() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",5);
-        Input input = new Input("input1",null,false,false,true);
+        Input input = new Input("input1",null,false,false,true, null);
         List<Input> inputs = Arrays.asList(input);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals("override disables the assignFrom func...",null, result.get("input1"));
@@ -243,10 +242,10 @@ public class InputsBindingTest {
     public void testOverrideFalse() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",5);
-        Input input = new Input("input1","6",false,false,false);
+        Input input = new Input("input1","6",false,false,false, null);
         List<Input> inputs = Arrays.asList(input);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(5, result.get("input1"));
@@ -257,10 +256,10 @@ public class InputsBindingTest {
     public void testExpressionWithWrongRef() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
 
-        Input input = new Input("input1","input2",false,false,false);
+        Input input = new Input("input1","input2",false,false,false, null);
         List<Input> inputs = Arrays.asList(input);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(null, result.get("input1"));
@@ -271,11 +270,11 @@ public class InputsBindingTest {
     public void testInputAssignFromAnotherInput() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
 
-        Input input1 = new Input("input1","5",false,false,false);
+        Input input1 = new Input("input1","5",false,false,false, null);
         Input input2 = new Input("input2","input1");
         List<Input> inputs = Arrays.asList(input1,input2);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(5, result.get("input1"));
@@ -291,11 +290,11 @@ public class InputsBindingTest {
         Map<String,Serializable> context = new HashMap<>();
         context.put("varX",5);
 
-        Input input1 = new Input("input1","5",false,false,false);
+        Input input1 = new Input("input1","5",false,false,false, null);
         Input input2 = new Input("input2","input1 + 5 + varX");
         List<Input> inputs = Arrays.asList(input1,input2);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals(5, result.get("input1"));
@@ -311,10 +310,10 @@ public class InputsBindingTest {
         Map<String,Serializable> context = new HashMap<>();
         context.put("varX","roles");
 
-        Input input1 = new Input("input1","\"mighty\" + ' max '   + varX",false,false,false);
+        Input input1 = new Input("input1","\"mighty\" + ' max '   + varX",false,false,false, null);
         List<Input> inputs = Arrays.asList(input1);
 
-        Map<String,Serializable> result = inputsBinding.bindInputs(context,inputs);
+        Map<String,Serializable> result = bindInputs(inputs, context);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
         Assert.assertEquals("mighty max roles", result.get("input1"));
@@ -323,10 +322,17 @@ public class InputsBindingTest {
         Assert.assertEquals("orig context should not change",1,context.size());
     }
 
-
     private Input createDefaultValueInput(String value){
-        return new Input("input1",value,false,false,false);
+        return new Input("input1", value, false, false, false, null);
     }
+
+	private Map<String, Serializable> bindInputs(List<Input> inputs, Map<String, Serializable> context) {
+		return inputsBinding.bindInputs(inputs, context, null);
+	}
+
+	private Map<String, Serializable> bindInputs(List<Input> inputs) {
+		return bindInputs(inputs, new HashMap<String, Serializable>());
+	}
 
     @Configuration
     static class Config{

--- a/score-lang-runtime/src/test/java/org/openscore/lang/runtime/bindings/InputsBindingTest.java
+++ b/score-lang-runtime/src/test/java/org/openscore/lang/runtime/bindings/InputsBindingTest.java
@@ -1,13 +1,12 @@
-/*******************************************************************************
-* (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Apache License v2.0 which accompany this distribution.
-*
-* The Apache License is available at
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-*******************************************************************************/
-
+/*
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
 package org.openscore.lang.runtime.bindings;
 
 import org.openscore.lang.entities.bindings.Input;
@@ -22,8 +21,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
+
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +45,7 @@ public class InputsBindingTest {
 
     @Test
     public void testDefaultValue() throws Exception {
-        List<Input> inputs = Arrays.asList(createDefaultValueInput("str('value')"));
+		List<Input> inputs = Arrays.asList(new Input("input1", "str('value')"));
         Map<String,Serializable> result = bindInputs(inputs);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
@@ -53,7 +54,7 @@ public class InputsBindingTest {
 
     @Test
     public void testDefaultValueInt() throws Exception {
-        List<Input> inputs = Arrays.asList(createDefaultValueInput("2"));
+        List<Input> inputs = Arrays.asList(new Input("input1", "2"));
         Map<String,Serializable> result = bindInputs(inputs);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
@@ -71,7 +72,7 @@ public class InputsBindingTest {
 
     @Test
     public void testTwoInputs() throws Exception {
-        List<Input> inputs =  Arrays.asList(new Input("input2","'yyy'",false,false,false, null),createDefaultValueInput("'zzz'"));
+		List<Input> inputs = Arrays.asList(new Input("input2", "'yyy'"), new Input("input1", "'zzz'"));
         Map<String,Serializable> result = bindInputs(inputs);
         Assert.assertFalse(result.isEmpty());
         Assert.assertTrue(result.containsKey("input1"));
@@ -124,7 +125,7 @@ public class InputsBindingTest {
     public void testDefaultValueVsEmptyRef() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
 
-        Input refInput = new Input("input1","str('val')",false,false,false, null);
+		Input refInput = new Input("input1", "str('val')");
         List<Input> inputs = Arrays.asList(refInput);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -139,7 +140,7 @@ public class InputsBindingTest {
     public void testAssignFromAndExpr() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",3);
-        Input input = new Input("input1","5+7",false,false,false, null);
+		Input input = new Input("input1", "5+7");
         List<Input> inputs = Arrays.asList(input);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -155,7 +156,7 @@ public class InputsBindingTest {
     public void testAssignFromAndConst() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",3);
-        Input input = new Input("input1","5",false,false,false, null);
+		Input input = new Input("input1", "5");
         List<Input> inputs = Arrays.asList(input);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -168,7 +169,7 @@ public class InputsBindingTest {
     public void testComplexExpr() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",3);
-        Input input = new Input("input2"," input1 + 3 * 2 ",false,false,false, null);
+		Input input = new Input("input2", " input1 + 3 * 2 ");
         List<Input> inputs = Arrays.asList(input);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -183,7 +184,7 @@ public class InputsBindingTest {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input2",3);
         context.put("input1",5);
-        Input input = new Input("input1","input2",false,false,false, null);
+		Input input = new Input("input1", "input2");
         List<Input> inputs = Arrays.asList(input);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -198,7 +199,7 @@ public class InputsBindingTest {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input2",3);
         context.put("input1",5);
-        Input input = new Input("input1","input2",false,false,true, null);
+		Input input = new Input("input1", "input2", false, false, true, null);
         List<Input> inputs = Arrays.asList(input);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -214,7 +215,7 @@ public class InputsBindingTest {
     public void testOverrideAssignFrom2() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",5);
-        Input input = new Input("input1","3",false,false,true, null);
+		Input input = new Input("input1", "3", false, false, true, null);
         List<Input> inputs = Arrays.asList(input);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -228,7 +229,7 @@ public class InputsBindingTest {
     public void testOverrideAssignFrom3() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",5);
-        Input input = new Input("input1",null,false,false,true, null);
+		Input input = new Input("input1", null, false, false, true, null);
         List<Input> inputs = Arrays.asList(input);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -242,7 +243,7 @@ public class InputsBindingTest {
     public void testOverrideFalse() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
         context.put("input1",5);
-        Input input = new Input("input1","6",false,false,false, null);
+		Input input = new Input("input1", "6");
         List<Input> inputs = Arrays.asList(input);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -256,7 +257,7 @@ public class InputsBindingTest {
     public void testExpressionWithWrongRef() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
 
-        Input input = new Input("input1","input2",false,false,false, null);
+		Input input = new Input("input1", "input2", false, false, false, null);
         List<Input> inputs = Arrays.asList(input);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -270,7 +271,7 @@ public class InputsBindingTest {
     public void testInputAssignFromAnotherInput() throws Exception {
         Map<String,Serializable> context = new HashMap<>();
 
-        Input input1 = new Input("input1","5",false,false,false, null);
+		Input input1 = new Input("input1", "5");
         Input input2 = new Input("input2","input1");
         List<Input> inputs = Arrays.asList(input1,input2);
 
@@ -290,7 +291,7 @@ public class InputsBindingTest {
         Map<String,Serializable> context = new HashMap<>();
         context.put("varX",5);
 
-        Input input1 = new Input("input1","5",false,false,false, null);
+		Input input1 = new Input("input1", "5");
         Input input2 = new Input("input2","input1 + 5 + varX");
         List<Input> inputs = Arrays.asList(input1,input2);
 
@@ -310,7 +311,7 @@ public class InputsBindingTest {
         Map<String,Serializable> context = new HashMap<>();
         context.put("varX","roles");
 
-        Input input1 = new Input("input1","\"mighty\" + ' max '   + varX",false,false,false, null);
+		Input input1 = new Input("input1", "\"mighty\" + ' max '   + varX");
         List<Input> inputs = Arrays.asList(input1);
 
         Map<String,Serializable> result = bindInputs(inputs, context);
@@ -322,12 +323,60 @@ public class InputsBindingTest {
         Assert.assertEquals("orig context should not change",1,context.size());
     }
 
-    private Input createDefaultValueInput(String value){
-        return new Input("input1", value, false, false, false, null);
-    }
+	@Test
+	public void testVariable() throws Exception {
+		String in = "input1";
+		String fqvn = "docker.env.vars.port";
+		List<Input> inputs = Arrays.asList(new Input(in, null, false, true, false, fqvn));
+		Map<String, Serializable> result = bindInputs(inputs, new HashMap<String, Serializable>(), Collections.singletonMap(fqvn, 22));
+		Assert.assertFalse(result.isEmpty());
+		Assert.assertEquals(1, result.size());
+		Assert.assertTrue(result.containsKey(in));
+		Assert.assertEquals(22, result.get(in));
+	}
 
-	private Map<String, Serializable> bindInputs(List<Input> inputs, Map<String, Serializable> context) {
-		return inputsBinding.bindInputs(inputs, context, null);
+	@Test
+	public void testVariableMissing() throws Exception {
+		String in = "input1";
+		String fqvn = "docker.env.vars.port";
+		List<Input> inputs = Arrays.asList(new Input(in, null, false, false, false, fqvn));
+		Map<String, Serializable> result = bindInputs(inputs, new HashMap<String, Serializable>());
+		Assert.assertFalse(result.isEmpty());
+		Assert.assertEquals(1, result.size());
+		Assert.assertTrue(result.containsKey(in));
+		Assert.assertEquals(null, result.get(in));
+	}
+
+	@Test
+	public void testVariableContext() throws Exception {
+		String in = "input1";
+		String fqvn = "docker.env.vars.port";
+		List<Input> inputs = Arrays.asList(new Input(in, null, false, true, false, fqvn));
+		Map<String, Serializable> result = bindInputs(inputs, Collections.singletonMap(in, 23), Collections.singletonMap(fqvn, 22));
+		Assert.assertFalse(result.isEmpty());
+		Assert.assertEquals(1, result.size());
+		Assert.assertTrue(result.containsKey(in));
+		Assert.assertEquals(23, result.get(in));
+	}
+
+	@Test
+	public void testVariableOverride() throws Exception {
+		String in = "input1";
+		String fqvn = "docker.env.vars.port";
+		List<Input> inputs = Arrays.asList(new Input(in, null, false, true, true, fqvn));
+		Map<String, Serializable> result = bindInputs(inputs, Collections.singletonMap(in, 23), Collections.singletonMap(fqvn, 22));
+		Assert.assertFalse(result.isEmpty());
+		Assert.assertEquals(1, result.size());
+		Assert.assertTrue(result.containsKey(in));
+		Assert.assertEquals(22, result.get(in));
+	}
+
+	private Map<String, Serializable> bindInputs(List<Input> inputs, Map<String, ? extends Serializable> context, Map<String, ? extends Serializable> variables) {
+		return inputsBinding.bindInputs(inputs, context, variables);
+	}
+
+	private Map<String, Serializable> bindInputs(List<Input> inputs, Map<String, ? extends Serializable> context) {
+		return bindInputs(inputs, context, null);
 	}
 
 	private Map<String, Serializable> bindInputs(List<Input> inputs) {

--- a/score-lang-runtime/src/test/java/org/openscore/lang/runtime/steps/ExecutableStepsTest.java
+++ b/score-lang-runtime/src/test/java/org/openscore/lang/runtime/steps/ExecutableStepsTest.java
@@ -84,7 +84,7 @@ public class ExecutableStepsTest {
         Map<String,Serializable> resultMap = new HashMap<>();
         resultMap.put("input1",5);
 
-        when(inputsBinding.bindInputs(anyMap(),eq(inputs))).thenReturn(resultMap);
+        when(inputsBinding.bindInputs(eq(inputs), anyMap(), anyMap())).thenReturn(resultMap);
         executableSteps.startExecutable(inputs, runEnv, new HashMap<String, Serializable>(), new ExecutionRuntimeServices(),"", 2L);
 
         Map<String,Serializable> opContext = runEnv.getStack().popContext();
@@ -99,14 +99,14 @@ public class ExecutableStepsTest {
 
     @Test
     public void testBoundInputEvent(){
-        List<Input> inputs = Arrays.asList(new Input("input1","input1"),new Input("input2", "3", true, true, true));
+        List<Input> inputs = Arrays.asList(new Input("input1","input1"),new Input("input2", "3", true, true, true, null));
         RunEnvironment runEnv = new RunEnvironment();
         ExecutionRuntimeServices runtimeServices = new ExecutionRuntimeServices();
         Map<String,Serializable> resultMap = new HashMap<>();
         resultMap.put("input1", 5);
         resultMap.put("input2", 3);
 
-        when(inputsBinding.bindInputs(anyMap(),eq(inputs))).thenReturn(resultMap);
+        when(inputsBinding.bindInputs(eq(inputs), anyMap(), anyMap())).thenReturn(resultMap);
         executableSteps.startExecutable(inputs, runEnv, new HashMap<String, Serializable>(), runtimeServices, "dockerizeStep", 2L);
         Collection<ScoreEvent> events = runtimeServices.getEvents();
 

--- a/score-lang-runtime/src/test/java/org/openscore/lang/runtime/steps/TaskStepsTest.java
+++ b/score-lang-runtime/src/test/java/org/openscore/lang/runtime/steps/TaskStepsTest.java
@@ -103,7 +103,7 @@ public class TaskStepsTest {
         resultMap.put("input1",5);
         resultMap.put("input2",3);
 
-        when(inputsBinding.bindInputs(anyMap(),eq(inputs))).thenReturn(resultMap);
+        when(inputsBinding.bindInputs(eq(inputs), anyMap(), anyMap())).thenReturn(resultMap);
 
         ExecutionRuntimeServices runtimeServices = createRuntimeServices();
         taskSteps.beginTask(inputs,runEnv,runtimeServices,"task1", 1L, 2L, "2");

--- a/score-language-tests/src/main/java/org/openscore/lang/systemtests/TriggerFlows.java
+++ b/score-language-tests/src/main/java/org/openscore/lang/systemtests/TriggerFlows.java
@@ -35,7 +35,7 @@ public class TriggerFlows {
     @Autowired
     private Slang slang;
 
-    public ScoreEvent runSync(CompilationArtifact compilationArtifact, Map<String, Serializable> userInputs) {
+    public ScoreEvent runSync(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> userInputs, Map<String, ? extends Serializable> variables) {
         final BlockingQueue<ScoreEvent> finishEvent = new LinkedBlockingQueue<>(1);
         ScoreEventListener finishListener = new ScoreEventListener() {
             @Override
@@ -45,7 +45,7 @@ public class TriggerFlows {
         };
         slang.subscribeOnEvents(finishListener, FINISHED_EVENT);
 
-        slang.run(compilationArtifact, userInputs);
+        slang.run(compilationArtifact, userInputs, variables);
 
         try {
             ScoreEvent event = finishEvent.take();
@@ -56,11 +56,11 @@ public class TriggerFlows {
         }
     }
 
-    public Map<String, StepData> runWithData(CompilationArtifact compilationArtifact, Map<String, Serializable> userInputs) {
+    public Map<String, StepData> runWithData(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> userInputs, Map<String, ? extends Serializable> variables) {
         RunDataAggregatorListener listener = new RunDataAggregatorListener();
         slang.subscribeOnEvents(listener, STEP_EVENTS);
 
-        runSync(compilationArtifact, userInputs);
+        runSync(compilationArtifact, userInputs, variables);
 
         Map<String, StepData> tasks = listener.aggregate();
 

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/OperationSystemTest.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/OperationSystemTest.java
@@ -36,7 +36,7 @@ public class OperationSystemTest extends SystemsTestsParent {
         CompilationArtifact compilationArtifact = slang.compileOperation(SlangSource.fromFile(resource.toURI()), "test_op", null);
         //Trigger ExecutionPlan
         Map<String, Serializable> userInputs = new HashMap<>();
-        ScoreEvent event = trigger(compilationArtifact, userInputs);
+        ScoreEvent event = trigger(compilationArtifact, userInputs, null);
         Assert.assertEquals(ScoreLangConstants.EVENT_EXECUTION_FINISHED, event.getEventType());
     }
 
@@ -50,7 +50,7 @@ public class OperationSystemTest extends SystemsTestsParent {
         userInputs.put("input2", "value2");
         userInputs.put("input4", "value4");
         userInputs.put("input5", "value5");
-        ScoreEvent event = trigger(compilationArtifact, userInputs);
+        ScoreEvent event = trigger(compilationArtifact, userInputs, null);
         Assert.assertEquals(ScoreLangConstants.EVENT_EXECUTION_FINISHED, event.getEventType());
     }
 }

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/SimpleFlowTest.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/SimpleFlowTest.java
@@ -57,7 +57,7 @@ public class SimpleFlowTest extends SystemsTestsParent {
 
         Map<String, Serializable> userInputs = new HashMap<>();
         userInputs.put("object_value", "SessionValue");
-        ScoreEvent event = trigger(compilationArtifact, userInputs);
+        ScoreEvent event = trigger(compilationArtifact, userInputs, null);
         Assert.assertEquals(ScoreLangConstants.EVENT_EXECUTION_FINISHED, event.getEventType());
     }
 
@@ -66,13 +66,15 @@ public class SimpleFlowTest extends SystemsTestsParent {
 		URI flow = getClass().getResource("/yaml/simple_flow.yaml").toURI();
 		URI operations = getClass().getResource("/yaml/simple_operations.yaml").toURI();
         SlangSource operationsSource = SlangSource.fromFile(operations);
+		URI vars = getClass().getResource("/yaml/simple_variables.yaml").toURI();
+		SlangSource varsSource = SlangSource.fromFile(vars);
         Set<SlangSource> path = Sets.newHashSet(operationsSource);
 		CompilationArtifact compilationArtifact = slang.compile(SlangSource.fromFile(flow), path);
 		HashMap<String, Serializable> userInputs = new HashMap<>();
         for (Entry<String, ? extends Serializable> input : inputs) {
             userInputs.put(input.getKey(), input.getValue());
         }
-		ScoreEvent event = trigger(compilationArtifact, userInputs);
+		ScoreEvent event = trigger(compilationArtifact, userInputs, slang.loadVariables(varsSource));
 		Assert.assertEquals(ScoreLangConstants.EVENT_EXECUTION_FINISHED, event.getEventType());
 	}
 

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/SubFlowSystemTest.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/SubFlowSystemTest.java
@@ -8,17 +8,16 @@
 *
 *******************************************************************************/
 
-package org.openscore.lang.systemtests.flows;
+package org.openscore.lang.systemtests;
 
 import com.google.common.collect.Sets;
+
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.openscore.events.EventConstants;
 import org.openscore.events.ScoreEvent;
 import org.openscore.lang.compiler.SlangSource;
 import org.openscore.lang.entities.CompilationArtifact;
-import org.openscore.lang.systemtests.SystemsTestsParent;
+import org.openscore.lang.entities.ScoreLangConstants;
 
 import java.io.Serializable;
 import java.net.URI;
@@ -26,28 +25,25 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-/**
-* Date: 11/17/2014
-*
-* @author Bonczidai Levente
-*/
-public class createDbContainerTest  extends SystemsTestsParent {
+/*
+ * Created by orius123 on 12/11/14.
+ */
+public class SubFlowSystemTest extends SystemsTestsParent {
 
     @Test
-    @Ignore
     public void testCompileAndRunSubFlowBasic() throws Exception {
-        URI resource = getClass().getResource("/yaml/docker-demo/create_db_container.yaml").toURI();
-        URI operations = getClass().getResource("/yaml/docker-demo/").toURI();
-
-        Set<SlangSource> path = Sets.newHashSet(SlangSource.fromFile(operations));
+        URI resource = getClass().getResource("/yaml/sub-flow/parent_flow.yaml").toURI();
+        URI subFlow = getClass().getResource("/yaml/sub-flow/child_flow.yaml").toURI();
+        URI operations = getClass().getResource("/yaml/simple_operations.yaml").toURI();
+        Set<SlangSource> path = Sets.newHashSet(SlangSource.fromFile(subFlow), SlangSource.fromFile(operations));
         CompilationArtifact compilationArtifact = slang.compile(SlangSource.fromFile(resource), path);
 
         Map<String, Serializable> userInputs = new HashMap<>();
-        userInputs.put("host", "{{ host }}");
-        userInputs.put("username", "{{ username }}");
-        userInputs.put("password", "{{ password }}");
-        ScoreEvent event = trigger(compilationArtifact, userInputs, null);
-        Assert.assertEquals(EventConstants.SCORE_FINISHED_EVENT, event.getEventType());
+        userInputs.put("input1", "value1");
+		URI vars = getClass().getResource("/yaml/simple_variables.yaml").toURI();
+		SlangSource varsSource = SlangSource.fromFile(vars);
+        ScoreEvent event = trigger(compilationArtifact, userInputs, slang.loadVariables(varsSource));
+        Assert.assertEquals(ScoreLangConstants.EVENT_EXECUTION_FINISHED, event.getEventType());
     }
 
 }

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/SubFlowSystemTests.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/SubFlowSystemTests.java
@@ -34,15 +34,13 @@ public class SubFlowSystemTests extends SystemsTestsParent {
         URI resource = getClass().getResource("/yaml/sub-flow/parent_flow.yaml").toURI();
         URI subFlow = getClass().getResource("/yaml/sub-flow/child_flow.yaml").toURI();
         URI operations = getClass().getResource("/yaml/simple_operations.yaml").toURI();
-
-        SlangSource subFlowDep = SlangSource.fromFile(subFlow);
-        SlangSource operationsDep = SlangSource.fromFile(operations);
-        Set<SlangSource> path = Sets.newHashSet(subFlowDep, operationsDep);
+URI operations2 = getClass().getResource("/yaml/sub-flow/simple_operations.yaml").toURI();
+        Set<SlangSource> path = Sets.newHashSet(SlangSource.fromFile(subFlow), SlangSource.fromFile(operations), SlangSource.fromFile(operations2));
         CompilationArtifact compilationArtifact = slang.compile(SlangSource.fromFile(resource), path);
 
         Map<String, Serializable> userInputs = new HashMap<>();
         userInputs.put("input1", "value1");
-        ScoreEvent event = trigger(compilationArtifact, userInputs);
+        ScoreEvent event = trigger(compilationArtifact, userInputs, null);
         Assert.assertEquals(EventConstants.SCORE_FINISHED_EVENT, event.getEventType());
     }
 }

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/SystemsTestsParent.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/SystemsTestsParent.java
@@ -30,16 +30,15 @@ public class SystemsTestsParent {
 
     @Autowired
     protected Slang slang;
-
     @Autowired
     protected TriggerFlows triggerFlows;
 
-    protected ScoreEvent trigger(CompilationArtifact compilationArtifact, Map<String, Serializable> userInputs) {
-        return triggerFlows.runSync(compilationArtifact, userInputs);
+    protected ScoreEvent trigger(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> userInputs, Map<String, ? extends Serializable> variables) {
+        return triggerFlows.runSync(compilationArtifact, userInputs, variables);
     }
 
-    public Map<String, StepData> triggerWithData(
-            CompilationArtifact compilationArtifact, Map<String, Serializable> userInputs) {
-        return triggerFlows.runWithData(compilationArtifact, userInputs);
-    }
+	public Map<String, StepData> triggerWithData(CompilationArtifact compilationArtifact, Map<String, ? extends Serializable> userInputs, Map<String, ? extends Serializable> variables) {
+		return triggerFlows.runWithData(compilationArtifact, userInputs, variables);
+	}
+
 }

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/ClearContainersTest.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/ClearContainersTest.java
@@ -49,7 +49,7 @@ public class ClearContainersTest  extends SystemsTestsParent {
         userInputs.put("dockerHost", "{{ dockerHost }}");
         userInputs.put("dockerUsername", "{{ dockerUsername }}");
         userInputs.put("dockerPassword", "{{ dockerPassword }}");
-        ScoreEvent event = trigger(compilationArtifact, userInputs);
+        ScoreEvent event = trigger(compilationArtifact, userInputs, null);
         Assert.assertEquals(EventConstants.SCORE_FINISHED_EVENT, event.getEventType());
     }
 }

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/CreateDbContainerTest.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/CreateDbContainerTest.java
@@ -8,15 +8,17 @@
 *
 *******************************************************************************/
 
-package org.openscore.lang.systemtests;
+package org.openscore.lang.systemtests.flows;
 
 import com.google.common.collect.Sets;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openscore.events.EventConstants;
 import org.openscore.events.ScoreEvent;
 import org.openscore.lang.compiler.SlangSource;
 import org.openscore.lang.entities.CompilationArtifact;
+import org.openscore.lang.systemtests.SystemsTestsParent;
 
 import java.io.Serializable;
 import java.net.URI;
@@ -24,23 +26,28 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-/*
- * Created by orius123 on 12/11/14.
- */
-public class SubFlowSystemTests extends SystemsTestsParent {
+/**
+* Date: 11/17/2014
+*
+* @author Bonczidai Levente
+*/
+public class CreateDbContainerTest  extends SystemsTestsParent {
 
     @Test
-    public void testCompileAndRunSubFlowBasic() throws Exception {
-        URI resource = getClass().getResource("/yaml/sub-flow/parent_flow.yaml").toURI();
-        URI subFlow = getClass().getResource("/yaml/sub-flow/child_flow.yaml").toURI();
-        URI operations = getClass().getResource("/yaml/simple_operations.yaml").toURI();
-URI operations2 = getClass().getResource("/yaml/sub-flow/simple_operations.yaml").toURI();
-        Set<SlangSource> path = Sets.newHashSet(SlangSource.fromFile(subFlow), SlangSource.fromFile(operations), SlangSource.fromFile(operations2));
+    @Ignore
+    public void testCreateDbContainer() throws Exception {
+        URI resource = getClass().getResource("/yaml/docker-demo/create_db_container.yaml").toURI();
+        URI operations = getClass().getResource("/yaml/docker-demo/").toURI();
+
+        Set<SlangSource> path = Sets.newHashSet(SlangSource.fromFile(operations));
         CompilationArtifact compilationArtifact = slang.compile(SlangSource.fromFile(resource), path);
 
         Map<String, Serializable> userInputs = new HashMap<>();
-        userInputs.put("input1", "value1");
+        userInputs.put("host", "{{ host }}");
+        userInputs.put("username", "{{ username }}");
+        userInputs.put("password", "{{ password }}");
         ScoreEvent event = trigger(compilationArtifact, userInputs, null);
         Assert.assertEquals(EventConstants.SCORE_FINISHED_EVENT, event.getEventType());
     }
+
 }

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/DataFlowTest.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/DataFlowTest.java
@@ -46,7 +46,7 @@ public class DataFlowTest extends SystemsTestsParent {
         userInputs.put("myMessage", "hello world");
         userInputs.put("tryToChangeMessage", "changed");
 
-        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs);
+        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs, null);
 
         Assert.assertEquals(3, tasks.size());
         Assert.assertEquals(ScoreLangConstants.SUCCESS_RESULT, tasks.get("0/0").getResult());

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/DevOpsDemoTest.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/DevOpsDemoTest.java
@@ -46,7 +46,7 @@ public class DevOpsDemoTest extends SystemsTestsParent {
         userInputs.put("emailPort", "{{ emailPort }}");
         userInputs.put("emailSender", "{{ emailSender }}");
         userInputs.put("emailRecipient", "{{ emailRecipient }}");
-        ScoreEvent event = trigger(compilationArtifact, userInputs);
+        ScoreEvent event = trigger(compilationArtifact, userInputs, null);
         Assert.assertEquals(EventConstants.SCORE_FINISHED_EVENT, event.getEventType());
     }
 }

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/NavigationTest.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/NavigationTest.java
@@ -46,7 +46,7 @@ public class NavigationTest extends SystemsTestsParent {
         userInputs.put("emailSender", "user@host.com");
         userInputs.put("emailRecipient", "user@host.com");
 
-        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs);
+        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs, null);
 
         Assert.assertEquals(5, tasks.size());
         Assert.assertEquals("check_number", tasks.get("0/1").getName());
@@ -70,7 +70,7 @@ public class NavigationTest extends SystemsTestsParent {
         userInputs.put("emailSender", "user@host.com");
         userInputs.put("emailRecipient", "user@host.com");
 
-        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs);
+        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs, null);
 
         Assert.assertEquals(5, tasks.size());
         Assert.assertEquals("check_number", tasks.get("0/1").getName());
@@ -94,7 +94,7 @@ public class NavigationTest extends SystemsTestsParent {
         userInputs.put("emailSender", "user@host.com");
         userInputs.put("emailRecipient", "user@host.com");
 
-        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs);
+        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs, null);
 
         Assert.assertEquals(5, tasks.size());
         Assert.assertEquals("check_number", tasks.get("0/1").getName());
@@ -118,7 +118,7 @@ public class NavigationTest extends SystemsTestsParent {
         userInputs.put("emailSender", "user@host.com");
         userInputs.put("emailRecipient", "user@host.com");
 
-        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs);
+        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs, null);
 
         Assert.assertEquals(5, tasks.size());
         Assert.assertEquals("produce_default_navigation", tasks.get("0/1").getName());
@@ -142,7 +142,7 @@ public class NavigationTest extends SystemsTestsParent {
         userInputs.put("emailSender", "user@host.com");
         userInputs.put("emailRecipient", "user@host.com");
 
-        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs);
+        Map<String, StepData> tasks = triggerWithData(compilationArtifact, userInputs, null);
 
         Assert.assertEquals(5, tasks.size());
         Assert.assertEquals("produce_default_navigation", tasks.get("0/1").getName());

--- a/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/createDbContainerTest.java
+++ b/score-language-tests/src/test/java/org/openscore/lang/systemtests/flows/createDbContainerTest.java
@@ -46,7 +46,7 @@ public class createDbContainerTest  extends SystemsTestsParent {
         userInputs.put("host", "{{ host }}");
         userInputs.put("username", "{{ username }}");
         userInputs.put("password", "{{ password }}");
-        ScoreEvent event = trigger(compilationArtifact, userInputs);
+        ScoreEvent event = trigger(compilationArtifact, userInputs, null);
         Assert.assertEquals(EventConstants.SCORE_FINISHED_EVENT, event.getEventType());
     }
 

--- a/score-language-tests/src/test/resources/yaml/simple_flow.yaml
+++ b/score-language-tests/src/test/resources/yaml/simple_flow.yaml
@@ -9,6 +9,7 @@ namespace: user.flows
 
 imports:
   ops: user.ops
+  vars: test.env.vars
 
 flow:
   name: simple_flow
@@ -16,11 +17,15 @@ flow:
     - input1
     - time_zone_as_string:
         required: false
+    - host:
+        variable: vars.host
   workflow:
     Task1:
       do:
         ops.get_time_zone:
           - time_zone_as_string: time_zone_as_string if time_zone_as_string is not None else input1
+          - port:
+              variable: vars.port
       publish:
         - time_zone: time_zone
       navigate:

--- a/score-language-tests/src/test/resources/yaml/simple_operations.yaml
+++ b/score-language-tests/src/test/resources/yaml/simple_operations.yaml
@@ -7,6 +7,9 @@
 
 namespace: user.ops
 
+imports:
+  vars: test.env.vars
+
 operations:
   - test_op:
       action:
@@ -27,6 +30,8 @@ operations:
   - get_time_zone:
       inputs:
         - time_zone_as_string
+        - alla:
+            variable: vars.alla
       action:
         python_script: |
             time_zone_as_int = int(time_zone_as_string)

--- a/score-language-tests/src/test/resources/yaml/simple_variables.yaml
+++ b/score-language-tests/src/test/resources/yaml/simple_variables.yaml
@@ -1,0 +1,6 @@
+namespace: test.env.vars
+
+variables:
+  host: localhost
+  port: 22
+  alla: balla

--- a/score-language-tests/src/test/resources/yaml/sub-flow/child_flow.yaml
+++ b/score-language-tests/src/test/resources/yaml/sub-flow/child_flow.yaml
@@ -9,12 +9,18 @@ namespace: user.flows
 
 imports:
   ops: user.ops
+  vars: test.env.vars
 
 flow:
   name: child_flow
   inputs:
     - input1: "'value'"
   workflow:
+    Task0:
+      do:
+        ops.get_time_zone:
+          - time_zone_as_string:
+              variable: vars.port
     CheckWeather:
       do:
         ops.test_op:

--- a/score-language-tests/src/test/resources/yaml/sub-flow/parent_flow.yaml
+++ b/score-language-tests/src/test/resources/yaml/sub-flow/parent_flow.yaml
@@ -24,8 +24,6 @@ flow:
           - city: city if city is not None else input1
       publish:
         - kuku: weather
-      navigate:
-        KUKU: Task2
 
     Task2:
       do:


### PR DESCRIPTION
#### Motivation
Provide a way to specify and use common global parameters within operations and flows without the overhead of declaring them over and over again.
#### Name
Global Variables. Alternatives: Globals, Global Parameters, Environment Parameters, System Variables, Environment Variables, System Properties. Suggestions? Some combination of [Global/Environment/System] and [Parameters/Variables/Properties]

#### Discussed Approaches
There are several approaches, with their pros & cons. Feel free to add your own...
In first 3 options, the imports section will look like this:
```yaml
  imports:
    docker: docker.env.vars
    ssh: ssh.env.vars
```
And the variables file like this:
```yaml
  namespace: docker.env.vars
  variables:
    host: localhost
    port: 22
```
##### 1. Namespace aliases:
The imports & aliases should be declared in required files and referenced by the alias. Given the above example, the usage will look something like this:
```yaml
  inputs:
    - port: docker.port + 100
    - pty: ssh.pty
```
Compiler passes namespace mappings to runtime via actionData on corresponding steps. Variable files are loaded and stored on special global context with fully qualified names and remapped with the alias in required steps.
Pros: Relatively clear syntax, No string manipulations on user's expressions, Available in all expressions, Scope isolation to some extent.
Cons: Little bit complicated implementation, Some extra work on runtime.
##### 2. Namespace aliases + special syntax:
Suggested as a workaround for the extra work at runtime & string manipulation problem on expressions. Helps to some extent but still problematic.
```yaml
  inputs:
    - port: var[docker.port] + 100
    - pty: var[ssh.pty]
```
Compiler replaces the references to aliases/keys with fully qualified names. Variable files are loaded and stored on special global context with fully qualified names and resolved in runtime when required.
Pros: Available in all expressions, Scope isolation to some extent.
Cons: Cumbersome syntax, Some string manipulations on user's expressions.
##### 3. Inputs with special attribute:
The imports & aliases should be declared in required files and referenced by the alias only as keys in special attribute on inputs. Given the above example, the usage will look something like this:
```yaml
  inputs:
    - port:
        global: docker.port
    - pty:
        global: ssh.pty
```
Compiler replaces the references to aliases/keys with fully qualified names. Variable files are loaded and stored on special global context with fully qualified names and resolved in runtime when required.
Pros: Simpler implementation, Full scope isolation, Easy for reporting & validation.
Cons: Avialable only in inputs as keys, No expressions/output/publish/result, More verbose syntax, Usability?
##### 4. Syntax as usual:
No special syntax, imports & namespaces, simple resolution done only in runtime.
```yaml
  inputs:
    - port: docker_port + 100
    - pty: ssh_pty
```
Variable files are loaded and stored on simple read-only global context and looked up if not available on local context.
Pros: Simplest approach & implementation, Simple/clear/usual syntax, Easy integration with local context, Easy integration with other sources like environment variables, Easy for future/feature/implementation changes.
Cons: Somehow against the isolated contexts concept of the language (thought the feature itself implies that...)

**After some sessions & discussions, we've decided to go with option 3.**
#### Syntax
##### Variable file with yaml extension:
```yaml
namespace: docker.env.vars
variables:
  host: localhost
  port: 22
  ...
```
##### Imports section:
```yaml
imports:
  docker: docker.env.vars
  ssh: ssh.env.vars
```
##### Usage:
```yaml
  inputs:
    - port:
        variable: docker.port
    - pty:
        variable: ssh.pty
```
#### Scope
Globally available within inputs in the declaring file. Other bindings & expressions including input, output, publish & result may be built on top of such inputs.
#### Score Triggering API
No changes, `runtimeValues` in `TriggeringProperties` isn't the right candidate.
#### Slang CLI
The CLI `run` method will accept an additional argument containing comma separated list of variable files with `--vf` switch. Slang wrapper classes will be adjusted to support loading, parsing and mapping the supplied files and passing the variables to run.
#### Slang API
The `compile` method variants will optionally accept the variable sources like other dependencies through `Set<SlangSource>` dependencies parameter. Should it be mandatory?
The `run` method variants will accept an additional `Map<String, Serializable>` parameter containing the variables with fully qualified names and populate them on a new global context on `RunEnvironment`.
A new method `loadVariables(SlangSource... sources)` will be added to load, parse and map the variables into fully qualified names, returning the required `Map<String, Serializable>`. The actual implementation logic will be provided by compiler.
#### Slang runtime
`RunEnvironment` will introduce a new global context of type `Map<String, Serializable>` to hold fully qualified variable names mapped to values, populated by the variables passed to run and globally available through all steps.
During the resolution & binding process, the mentioned inputs containing fully qualified variable names will be looked up within the mentioned context if they aren't overridden by local context (unless `override=true` specified for the input).
#### Slang Compiler
The compiler should be aware of a new kind of yaml file containing the parameters, replace the references to the keys with fully qualified names or pass namespace mappings to runtime via actionData on corresponding steps and optionally load, validate & inject default values into the corresponding step.
A new method `loadVariables(SlangSource... sources)` will be added to load, parse and map the variables into fully qualified names, returning the required `Map<String, Serializable>`.
`ParsedSlang` will have an additional `Type` indicating the variable file and additional field of type `Map<String, Serializable>` to hold the parsed variables.
