### PR TITLE
NPM - A new way of getting the score command line interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,24 @@ Contact us at [here](mailto:support@openscore.io).
 2. ```mvn clean install```
 3. Run the CLI executable from score-lang-cli\target\slang\bin 
 
+# Another way of getting the score command line interface.
+# score-cli
+> The score command line interface.
+
+Install this globally and you'll have access to the `score` command anywhere on your system.
+
+```shell
+npm install -g score-cli
+```
+
+Now you can just use the `score` command anywhere
+```shell
+score
+```
+
+Refer to [openscore](http://openscore.io) website for more information.
+
+# Prerequisite
+Node.js installed.
+
+score-cli page in the [NPM repository](https://www.npmjs.com/package/score-cli).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ score
 Refer to [openscore](http://openscore.io) website for more information.
 
 # Prerequisite
-Node.js installed.
+Node.js & Java installed.
 
 score-cli page in the [NPM repository](https://www.npmjs.com/package/score-cli).


### PR DESCRIPTION
I’ve created and published an NPM package for score-cli.

GIT repository:
https://github.com/dorsha/score-cli

The NPM package page in the NPM repository:
https://www.npmjs.com/package/score-cli

So getting score has never been so easy! Just run in your command line:
npm install -g score-cli
(It might take a while in the HP network…)

And then you can just use ‘score’ command anywhere on your system:
score
