### PR TITLE
Changed MapConverter so that commas can be used as input values.

### DIFF
--- a/score-lang-cli/src/main/java/org/openscore/lang/cli/converters/MapConverter.java
+++ b/score-lang-cli/src/main/java/org/openscore/lang/cli/converters/MapConverter.java
@@ -30,6 +30,9 @@ import java.util.Map;
 
 @Component
 public class MapConverter implements Converter<Map<String, String>> {
+
+    public static final String ESCAPE_EXPRESSION = "\\&^\\&";
+
     @Override
     public boolean supports(Class<?> type, String optionContext) {
         return Map.class.isAssignableFrom(type);
@@ -37,14 +40,14 @@ public class MapConverter implements Converter<Map<String, String>> {
 
     @Override
     public Map<String, String> convertFromText(String value, Class<?> targetType, String optionContext) {
-        value = value.replace("\\,", "\\&^\\&");
+        value = value.replace("\\,", ESCAPE_EXPRESSION);
         String[] values = StringUtils.commaDelimitedListToStringArray(value);
         Map<String, String> map = new HashMap<>();
 
         for (String v : values) {
             String[] keyValue = StringUtils.delimitedListToStringArray(v, "=");
             if (keyValue.length == 2) {
-                keyValue[1] = keyValue[1].replace("\\&^\\&", ",");
+                keyValue[1] = keyValue[1].replace(ESCAPE_EXPRESSION, ",");
                 map.put(keyValue[0], keyValue[1]);
             } else {
                 throw new RuntimeException("Input should be in a key=value comma separated format, e.g. key1=val1,key2=val2 etc.");

--- a/score-lang-cli/src/main/java/org/openscore/lang/cli/converters/MapConverter.java
+++ b/score-lang-cli/src/main/java/org/openscore/lang/cli/converters/MapConverter.java
@@ -37,12 +37,14 @@ public class MapConverter implements Converter<Map<String, String>> {
 
     @Override
     public Map<String, String> convertFromText(String value, Class<?> targetType, String optionContext) {
+        value = value.replace("\\,", "\\&^\\&");
         String[] values = StringUtils.commaDelimitedListToStringArray(value);
         Map<String, String> map = new HashMap<>();
 
         for (String v : values) {
             String[] keyValue = StringUtils.delimitedListToStringArray(v, "=");
             if (keyValue.length == 2) {
+                keyValue[1] = keyValue[1].replace("\\&^\\&", ",");
                 map.put(keyValue[0], keyValue[1]);
             } else {
                 throw new RuntimeException("Input should be in a key=value comma separated format, e.g. key1=val1,key2=val2 etc.");

--- a/score-lang-cli/src/test/java/org/openscore/lang/cli/MapConverterTest.java
+++ b/score-lang-cli/src/test/java/org/openscore/lang/cli/MapConverterTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
+
+package org.openscore.lang.cli;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openscore.lang.cli.converters.MapConverter;
+
+import java.util.Map;
+
+/**
+ * Date: 2/16/2015
+ *
+ * @author lesant
+ */
+
+public class MapConverterTest {
+
+    public static final String VALID_INPUTS = "input1=value1,input2=value2";
+    public static final String INVALID_INPUTS_WRONG_DELIMITER = "input1=value1;input2=value2";
+    public static final String INVALID_INPUTS_CONCATENATED_VALUES = "input1=value1input2=value2";
+    public static final String VALID_INPUTS_WITH_COMMA = "input1=value1\\,value2,input2=value3\\,value4";
+    public static final String INVALID_INPUTS_UNESCAPED_COMMA = "input1=value1,value2,input2=value3,value4";
+    public static final String INPUT_1 = "input1";
+    public static final String INPUT_2 = "input2";
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private MapConverter mapConverter;
+
+    public MapConverterTest(){
+        mapConverter = new MapConverter();
+    }
+
+    @Test
+    public void testConvertSuccess(){
+        Map<String, String> inputs = mapConverter.convertFromText(VALID_INPUTS, null, null);
+        Assert.assertEquals("value1", inputs.get(INPUT_1));
+        Assert.assertEquals("value2", inputs.get(INPUT_2));
+    }
+    @Test
+    public void testConvertFailureWrongDelimiter(){
+        expectException();
+
+        Map<String, String> inputs = mapConverter.convertFromText(INVALID_INPUTS_WRONG_DELIMITER, null, null);
+        Assert.assertEquals(null, inputs);
+
+    }
+    @Test
+    public void testConvertFailureConcatenated(){
+        expectException();
+
+        Map<String, String> inputs = mapConverter.convertFromText(INVALID_INPUTS_CONCATENATED_VALUES, null, null);
+        Assert.assertEquals(null, inputs);
+
+    }
+    @Test
+    public void testConvertSuccessComma(){
+        Map<String, String> inputs = mapConverter.convertFromText(VALID_INPUTS_WITH_COMMA, null, null);
+        Assert.assertEquals("value1,value2", inputs.get(INPUT_1));
+        Assert.assertEquals("value3,value4", inputs.get(INPUT_2));
+    }
+
+    @Test
+    public void testConvertFailureComma(){
+        expectException();
+
+        Map<String, String> inputs = mapConverter.convertFromText(INVALID_INPUTS_UNESCAPED_COMMA, null, null);
+        Assert.assertEquals(null, inputs);
+    }
+
+    private void expectException() {
+        exception.expect(RuntimeException.class);
+        exception.expectMessage("Input");
+        exception.expectMessage("key=value");
+        exception.expectMessage("format");
+    }
+
+
+}


### PR DESCRIPTION
Now just escape the comma in the value. 
Example: run --f filepath --i input1=firstValue\,secondValue,input2=thirdValue. 

Notice the second comma is not escaped so everything after will be split into input2