### PR TITLE
Force each task name to be unique

### DIFF
--- a/score-lang-compiler/src/main/java/org/openscore/lang/compiler/modeller/ExecutableBuilder.java
+++ b/score-lang-compiler/src/main/java/org/openscore/lang/compiler/modeller/ExecutableBuilder.java
@@ -202,10 +202,16 @@ public class ExecutableBuilder {
         String defaultFailure = isOnFailureDefined ?
                 onFailureWorkFlow.getTasks().getFirst().getName() : FAILURE_RESULT;
 
+        Set<String> taskNames = new HashSet<>();
+
         while (iterator.hasNext()) {
             Map<String, Map<String, Object>> taskRawData = iterator.next();
             Map<String, Map<String, Object>> nextTaskData = iterator.peek();
             String taskName = taskRawData.keySet().iterator().next();
+            if(taskNames.contains(taskName)){
+                throw new RuntimeException("Task name: \'" + taskName + "\' appears more than once in the workflow. Each task name in the workflow must be unique");
+            }
+            taskNames.add(taskName);
             Map<String, Object> taskRawDataValue;
             String message = "Task: " + taskName + " syntax is illegal.\nBelow task name, there should be a map of values in the format:\ndo:\n\top_name:";
             try {

--- a/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompilerErrorsTest.java
+++ b/score-lang-compiler/src/test/java/org/openscore/lang/compiler/CompilerErrorsTest.java
@@ -363,4 +363,15 @@ public class CompilerErrorsTest {
         exception.expectMessage("3");
         compiler.compile(SlangSource.fromFile(resource), path);
     }
+
+    @Test
+    public void testDuplicateTaskNamesInFlow() throws Exception {
+        URI resource = getClass().getResource("/corrupted/duplicate_task_name.sl").toURI();
+
+        Set<SlangSource> path = new HashSet<>();
+        exception.expect(RuntimeException.class);
+        exception.expectMessage("Task1");
+        exception.expectMessage("unique");
+        compiler.compile(SlangSource.fromFile(resource), path);
+    }
 }

--- a/score-lang-compiler/src/test/resources/corrupted/duplicate_task_name.sl
+++ b/score-lang-compiler/src/test/resources/corrupted/duplicate_task_name.sl
@@ -1,0 +1,27 @@
+#   (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+#   All rights reserved. This program and the accompanying materials
+#   are made available under the terms of the Apache License v2.0 which accompany this distribution.
+#
+#   The Apache License is available at
+#   http://www.apache.org/licenses/LICENSE-2.0
+namespace: org.openscore
+
+imports:
+  ops: user.ops
+
+flow:
+  name: duplicate_task_name
+
+  workflow:
+    - Task1:
+        do:
+          ops.java_op:
+        navigate:
+          SUCCESS: SUCCESS
+          FAILURE: FAILURE
+    - Task1:
+        do:
+          ops.java_op:
+        navigate:
+          SUCCESS: SUCCESS
+          FAILURE: FAILURE


### PR DESCRIPTION
 Each task name in a workflow must be unique - add validation + test

Signed-off-by: Orit Stone <orit.stone@hp.com>