### PR TITLE
Allow several slang files with the same name and a different namespace

### DIFF
--- a/score-lang-content-verifier/src/main/java/org/openscore/lang/tools/verifier/SlangContentVerifier.java
+++ b/score-lang-content-verifier/src/main/java/org/openscore/lang/tools/verifier/SlangContentVerifier.java
@@ -88,17 +88,17 @@ public class SlangContentVerifier {
     }
 
     private int compileAllSlangModels(Map<String, Executable> slangModels)  {
-        Collection<Executable> models = slangModels.values();
         Map<String, CompilationArtifact> compiledArtifacts = new HashMap<>();
-        for(Executable slangModel : models) {
+        for(Map.Entry<String, Executable> slangModelEntry : slangModels.entrySet()) {
+            Executable slangModel = slangModelEntry.getValue();
             try {
                 Set<Executable> dependenciesModels = getModelDependenciesRecursively(slangModels, slangModel);
-                CompilationArtifact compiledSource = compiledArtifacts.get(slangModel.getName());
+                CompilationArtifact compiledSource = compiledArtifacts.get(getUniqueName(slangModel));
                 if (compiledSource == null) {
                     compiledSource = scoreCompiler.compile(slangModel, dependenciesModels);
                     if(compiledSource != null) {
                         log.info("Compiled: \'" + slangModel.getNamespace() + "." + slangModel.getName() + "\' successfully");
-                        compiledArtifacts.put(slangModel.getName(), compiledSource);
+                        compiledArtifacts.put(getUniqueName(slangModel), compiledSource);
                     } else {
                         log.error("Failed to compile source: \'" + slangModel.getNamespace() + "." + slangModel.getName() + "\'");
                     }


### PR DESCRIPTION
Fixes #148
Make the slang files full name (namespace+name) the identifier for the verifier, and not only the name

Signed-off-by: Orit Stone <orit.stone@hp.com>